### PR TITLE
Switch to a different URL scheme for web app

### DIFF
--- a/crates/humanode-peer/src/qrcode.rs
+++ b/crates/humanode-peer/src/qrcode.rs
@@ -15,8 +15,8 @@ impl WebApp {
         let mut url = Url::parse(base_url).map_err(|err| err.to_string())?;
         url.path_segments_mut()
             .map_err(|_| "invalid base URL".to_owned())?
-            .push("humanode")
-            .push(rpc_url);
+            .push("open");
+        url.query_pairs_mut().append_pair("url", rpc_url);
         Ok(Self { url })
     }
 
@@ -38,7 +38,7 @@ mod tests {
 
         assert_eq!(
             webapp.url,
-            Url::parse("https://example.com/humanode/http:%2F%2Flocalhost:9933").unwrap()
+            Url::parse("https://example.com/open?url=http%3A%2F%2Flocalhost%3A9933").unwrap()
         );
     }
 }


### PR DESCRIPTION
Solves the issue where a click on the URL in the terminal opens the page in the browser with RPC URL component URL-decoded, breaking the web app.