### PR TITLE
Runchain script

### DIFF
--- a/utils/runchain
+++ b/utils/runchain
@@ -56,10 +56,6 @@ for NODE in "${NODES[@]}"; do
     "$@" "${ARGS[@]}" 2>&1 | tee "$LOG_FILE"
   } &
 
-  NODE_PID="$!"
-
-  printf "node: %s\tlog: %s\tpid: %d\n" "$NODE" "$LOG_FILE" "$NODE_PID"
-
   ((P2P_PORT = P2P_PORT + 1))
   ((RPC_HTTP_PORT = RPC_HTTP_PORT + 1))
   ((RPC_WS_PORT = RPC_WS_PORT + 1))


### PR DESCRIPTION
This PR adds a neat utility to run multiple instances of a substrate-based chain. It can be used with `target/debug/humanode-peer`, `cargo run -p humanode-peer --` and even to experiment with other chains, i.e. `node-template` and `node` from substrate.