### PR TITLE
Enable telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2334,6 +2334,7 @@ dependencies = [
  "sc-executor",
  "sc-network",
  "sc-service",
+ "sc-telemetry 4.0.0-dev",
  "sc-tracing 4.0.0-dev",
  "sc-transaction-pool",
  "sp-application-crypto",

--- a/crates/humanode-peer/Cargo.toml
+++ b/crates/humanode-peer/Cargo.toml
@@ -34,6 +34,7 @@ sc-consensus-aura = { git = "https://github.com/humanode-network/substrate", bra
 sc-executor = { git = "https://github.com/humanode-network/substrate", branch = "master" }
 sc-network = { git = "https://github.com/humanode-network/substrate", branch = "master" }
 sc-service = { git = "https://github.com/humanode-network/substrate", branch = "master" }
+sc-telemetry = { git = "https://github.com/humanode-network/substrate", branch = "master" }
 sc-tracing = { git = "https://github.com/humanode-network/substrate", branch = "master" }
 sc-transaction-pool = { git = "https://github.com/humanode-network/substrate", branch = "master" }
 sp-application-crypto = { git = "https://github.com/humanode-network/substrate", branch = "master" }


### PR DESCRIPTION
This PR adds telemetry.

Please review carefully and double-check if I missed anything.

Either way, we can fix things letter if we encounter any issues.

We have the telemetry system deployed at https://telemetry.humanode.io/, and the cli flags to use is `--telemetry-url 'wss://record.telemetry.humanode.io/submit/ 0'`. I tried it, and some data shows up. Not sure it's everything or looks like expected.