### PR TITLE
Implement Auth URL subcommand

### DIFF
--- a/crates/humanode-peer/src/cli/run.rs
+++ b/crates/humanode-peer/src/cli/run.rs
@@ -98,6 +98,10 @@ pub async fn run() -> sc_cli::Result<()> {
                 })
                 .await
         }
+        Some(Subcommand::Bioauth(bioauth::BioauthCmd::AuthUrl(cmd))) => {
+            let runner = root.create_humanode_runner(cmd)?;
+            runner.sync_run(|config| cmd.run(config.bioauth_flow))
+        }
         Some(Subcommand::Benchmark(cmd)) => {
             if cfg!(feature = "runtime-benchmarks") {
                 let runner = root.create_humanode_runner(cmd)?;

--- a/crates/humanode-peer/src/cli/subcommand/bioauth/authurl.rs
+++ b/crates/humanode-peer/src/cli/subcommand/bioauth/authurl.rs
@@ -1,0 +1,55 @@
+//! Bioauth auth-url subcommand.
+
+use structopt::StructOpt;
+
+use crate::{
+    cli::{params, CliConfigurationExt, SubstrateCliConfigurationProvider},
+    configuration::BioauthFlow,
+    qrcode::WebApp,
+};
+
+/// The `bioauth auth-url` command.
+#[derive(Debug, StructOpt)]
+pub struct AuthUrlCmd {
+    #[allow(missing_docs, clippy::missing_docs_in_private_items)]
+    #[structopt(flatten)]
+    pub base: Box<sc_cli::RunCmd>,
+
+    #[allow(missing_docs, clippy::missing_docs_in_private_items)]
+    #[structopt(flatten)]
+    pub bioauth_flow_params: params::BioauthFlowParams,
+}
+
+impl AuthUrlCmd {
+    /// Run the command.
+    pub fn run(&self, bioauth_flow: Option<BioauthFlow>) -> sc_cli::Result<()> {
+        let (webapp_url, rpc_url) = match bioauth_flow {
+            Some(BioauthFlow {
+                webapp_url: Some(ref webapp_url),
+                rpc_url: Some(ref rpc_url),
+                ..
+            }) => (webapp_url, rpc_url),
+            _ => {
+                return Err("bioauth flow is not configured".into());
+            }
+        };
+
+        let webapp = WebApp::new(webapp_url, rpc_url)?;
+        println!("{}", webapp.url());
+        Ok(())
+    }
+}
+
+impl SubstrateCliConfigurationProvider for AuthUrlCmd {
+    type SubstrateCliConfiguration = sc_cli::RunCmd;
+
+    fn substrate_cli_configuration(&self) -> &Self::SubstrateCliConfiguration {
+        &self.base
+    }
+}
+
+impl CliConfigurationExt for AuthUrlCmd {
+    fn bioauth_params(&self) -> Option<&params::BioauthFlowParams> {
+        Some(&self.bioauth_flow_params)
+    }
+}

--- a/crates/humanode-peer/src/cli/subcommand/bioauth/mod.rs
+++ b/crates/humanode-peer/src/cli/subcommand/bioauth/mod.rs
@@ -2,6 +2,7 @@
 
 use structopt::StructOpt;
 
+pub mod authurl;
 pub mod key;
 
 /// Subcommands for the `bioauth` command.
@@ -9,4 +10,6 @@ pub mod key;
 pub enum BioauthCmd {
     /// Bioauth key utilities.
     Key(key::KeyCmd),
+    /// Web App URL with bound RPC URL.
+    AuthUrl(authurl::AuthUrlCmd),
 }

--- a/crates/humanode-peer/src/qrcode.rs
+++ b/crates/humanode-peer/src/qrcode.rs
@@ -20,6 +20,11 @@ impl WebApp {
         Ok(Self { url })
     }
 
+    /// Provide the Web App URL.
+    pub fn url(&self) -> &str {
+        self.url.as_str()
+    }
+
     /// Print the QR Code for the Web App to the terminal.
     pub fn print(&self) {
         info!("Please visit {} to proceed", self.url);


### PR DESCRIPTION
This is a command that prints the Web App URL with bound RPC URL.

It will be used by our desktop app to render the QR Code. 