### PR TITLE
Verify (and fix if broken) the ability to update the runtime without hard-forks

### DIFF
--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -54,6 +54,7 @@ runtime-benchmarks = [
   "sp-runtime/runtime-benchmarks",
 ]
 std = [
+  "bioauth-consensus-api/std",
   "primitives-auth-ticket/std",
   "codec/std",
   "serde",


### PR DESCRIPTION
Ref #173, not closing since that issue is a research task.

One of the main requirement to make forkless runtime upgrade on substrate is the ability to compile runtime logic to WASM.
- [x] fix if broken the ability to compile runtime logic to WASM.
- [x] verify the ability to add new features and logic by extending current chain state.
- [x] verify the ability to change existing business logic and chain state.