### PR TITLE
Build Apple Silicon at CI

### DIFF
--- a/.github/actions/plan/plan.js
+++ b/.github/actions/plan/plan.js
@@ -8,7 +8,8 @@ const allPlatforms = {
     os: "ubuntu-20.04",
     buildEnvScript: buildEnvScriptPath("ubuntu.sh"),
     essential: true,
-    env: {}
+    env: {},
+    cacheKey: "ubuntu-amd64",
   },
   windows: {
     name: "Windows",
@@ -18,6 +19,7 @@ const allPlatforms = {
     env: {
       CARGO_INCREMENTAL: "0"
     },
+    cacheKey: "windows-amd64",
   },
   macos: {
     name: "macOS (amd64)",
@@ -25,6 +27,7 @@ const allPlatforms = {
     buildEnvScript: buildEnvScriptPath("macos.sh"),
     essential: false,
     env: {},
+    cacheKey: "macos-amd64",
   },
   macos_aarch64: {
     name: "macOS (aarch64)",
@@ -32,6 +35,7 @@ const allPlatforms = {
     buildEnvScript: buildEnvScriptPath("macos.sh"),
     essential: false,
     env: {},
+    cacheKey: "macos-aarch64",
   },
 };
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           path: |
             /usr/share/rust/.rustup
-          key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain.toml') }}
+          key: ${{ matrix.platform.cacheKey }}-rustup-${{ hashFiles('rust-toolchain.toml') }}
 
       - name: Install rust toolchain
         run: rustup show
@@ -94,7 +94,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ matrix.mode.cargoCacheKey }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
+          key: ${{ matrix.platform.cacheKey }}-cargo-${{ matrix.mode.cargoCacheKey }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
 
       - name: Run cargo ${{ matrix.mode.cargoCommand }}
         uses: actions-rs/cargo@v1

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -69,7 +69,7 @@ jobs:
         with:
           path: |
             /usr/share/rust/.rustup
-          key: ${{ runner.os }}-rustup-${{ hashFiles('rust-toolchain.toml') }}
+          key: ${{ matrix.platform.cacheKey }}-rustup-${{ hashFiles('rust-toolchain.toml') }}
 
       - name: Install rust toolchain
         run: rustup show
@@ -98,7 +98,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-cargo-${{ matrix.mode.cargoCacheKey }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
+          key: ${{ matrix.platform.cacheKey }}-cargo-${{ matrix.mode.cargoCacheKey }}-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
 
       - name: Run cargo ${{ matrix.mode.cargoCommand }}
         uses: actions-rs/cargo@v1
@@ -125,7 +125,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-e2e-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
+          key: ${{ matrix.platform.cacheKey }}-e2e-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
 
       - name: Set up polkadot tools
         run: yarn install --frozen-lockfile
@@ -161,6 +161,6 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: ${{ runner.os }}-check-utils-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
+          key: ${{ matrix.platform.cacheKey }}-check-utils-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
 
       - run: ${{ matrix.util.run }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
             target/docker/*/*/cargo/registry/cache/
             target/docker/*/*/cargo/git/db/
             target/docker/*/*/target/
-          key: ${{ runner.os }}-docker-cargo-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
+          key: ${{ matrix.platform.cacheKey }}-docker-cargo-${{ hashFiles('rust-toolchain.toml', 'Cargo.lock') }}
 
       - name: Build the code and docker image
         run: docker/build.sh


### PR DESCRIPTION
This PR adds support for building the `humanode-peer` binary for Apple Silicon natively on a self-hosted M1 Mac Mini runner.

Apparently, it just works, with minimal setup. Just set up the runner with Rosetta and `amd64` architecture (Github Runner does not ship `aarch64` builds at the moment) - then install `brew`, then do `brew install rustup` and `rustup-init` - that's pretty much it.