### PR TITLE
Minor corrections to runtime configs around babe

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -333,7 +333,7 @@ impl pallet_babe::Config for Runtime {
     type EpochDuration = EpochDuration;
     type ExpectedBlockTime = ExpectedBlockTime;
     type EpochChangeTrigger = pallet_babe::ExternalTrigger;
-    type DisabledValidators = ();
+    type DisabledValidators = Session;
 
     type KeyOwnerProofSystem = Historical;
 


### PR DESCRIPTION
This PR applies some minor corrections to the runtime config, just to tie the loose ends, and ensure we have things operating as intended.