### PR TITLE
Set proper ss58 prefix

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -258,7 +258,7 @@ impl frame_system::Config for Runtime {
     type SystemWeightInfo = ();
     /// This is used as an identifier of the chain.
     /// 42 is the generic substrate prefix.
-    /// 5234 in Humanode prefix.
+    /// 5234 is Humanode prefix.
     type SS58Prefix = ConstU16<5234>;
     /// The set code logic, just the default since we're not a parachain.
     type OnSetCode = ();


### PR DESCRIPTION
This PR changes the network's built-in ss58 to use our proper value.

We should probably make it configurable at genesis, just like we have the EVM chain ID.