### PR TITLE
EVM accounts lookup

### DIFF
--- a/crates/humanode-runtime/src/dev_utils.rs
+++ b/crates/humanode-runtime/src/dev_utils.rs
@@ -5,7 +5,8 @@
 #![allow(dead_code)]
 
 use crypto_utils::{
-    authority_keys_from_seed, get_account_id_from_seed, get_account_public_from_seed,
+    authority_keys_from_seed, evm_account_from_seed, get_account_id_from_seed,
+    get_account_public_from_seed,
 };
 use sp_application_crypto::ByteArray;
 use sp_runtime::app_crypto::sr25519;
@@ -28,6 +29,16 @@ pub fn account_id(seed: &str) -> AccountId {
 /// A helper function to return authorities keys based on runtime data and provided seed.
 pub fn authority_keys(seed: &str) -> (AccountId, BabeId, GrandpaId, ImOnlineId) {
     authority_keys_from_seed::<sr25519::Public, AccountPublic, AccountId>(seed)
+}
+
+/// A helper function to return an EVM address based on the provided seed.
+pub fn evm_account_h160(seed: &str) -> H160 {
+    H160(evm_account_from_seed(seed))
+}
+
+/// A helper function to return an EVM address based on the provided seed.
+pub fn evm_account(seed: &str) -> EthereumAddress {
+    EthereumAddress(evm_account_from_seed(seed))
 }
 
 /// A helper function to get a corresponding EVM truncated address for provided `AccountId`.

--- a/crates/humanode-runtime/src/evm_address.rs
+++ b/crates/humanode-runtime/src/evm_address.rs
@@ -1,0 +1,72 @@
+use sp_runtime::{traits::LookupError, MultiAddress};
+
+use super::*;
+
+/// The EVM-aware address lookup for [`MultiAddress`].
+///
+/// The [`MultiAddress`] is a type that supports both "native" account ID (as [`MultiAddress::Id`])
+/// and, among other things, EVM-like 20-byte addresses (as [`MultiAddress::Address20`]).
+///
+/// We utilize this property to allow using both "native" and 20-byte addresses in our chain.
+/// This type, being part of the Substrate itself, and not part of our custom codebase,
+/// should be well supported by the node RPC API clients (like Polkadot.js API/Apps and subxt),
+/// so we can expect good compatibility in the existing ecosystem (well, at least this is one of
+/// the arguments for using this type in theory - we'll see how it plays out).
+pub struct MultiLookup<T>(core::marker::PhantomData<T>);
+
+impl<T> StaticLookup for MultiLookup<T>
+where
+    T: frame_system::Config + pallet_evm_accounts_mapping::Config,
+{
+    type Source = MultiAddress<T::AccountId, ()>;
+
+    type Target = T::AccountId;
+
+    fn lookup(s: Self::Source) -> Result<Self::Target, frame_support::error::LookupError> {
+        match s {
+            // Pass "native" address directly as-is.
+            MultiAddress::Id(id) => Ok(id),
+            // Map 20-byte address to a native address via ethereum address mapping pallet,
+            // if the mapping exists.
+            MultiAddress::Address20(ethereum_address) => {
+                let ethereum_address = primitives_ethereum::EthereumAddress(ethereum_address);
+                pallet_evm_accounts_mapping::Pallet::<T>::accounts(ethereum_address)
+                    .ok_or(LookupError)
+            }
+            _ => Err(LookupError),
+        }
+    }
+
+    fn unlookup(t: Self::Target) -> Self::Source {
+        // We unlookup from a native address, so we can naturally always output a native address.
+        // Note: this is only a good idea because we don't do the truncated EVM addresses.
+        // If we were doing this truncated magic, we'd want to map those truncated native addresses
+        // into their 20-byte form here.
+        // Since we always have a real "native" address for each EVM address in our current design -
+        // we just simply always prefer to unlookup into the "native" form.
+        MultiAddress::Id(t)
+    }
+}
+
+/// A [`pallet_evm::EnsureAddressOrigin`] implementation that performs the 20-byte address mapping
+/// via [`frame_system::Config::Lookup`], requiring that it uses a [`MultiAddress`] as a source
+/// and passing the [`MultiAddress::Address20`] as an input.
+///
+/// This way this implementation does not introduce anything new, but instead just relies on
+/// however the lookup is implemented, reducing the complexity of the mental model.
+pub struct SystemLookupAddressOrigin<T>(core::marker::PhantomData<T>);
+
+impl<T> pallet_evm::EnsureAddressOrigin<T::RuntimeOrigin> for SystemLookupAddressOrigin<T>
+where
+    T: frame_system::Config + pallet_evm_accounts_mapping::Config,
+    <T as frame_system::Config>::Lookup: StaticLookup<Source = MultiAddress<T::AccountId, ()>>,
+{
+    type Success = T::AccountId;
+
+    fn try_address_origin(
+        address: &H160,
+        origin: T::RuntimeOrigin,
+    ) -> Result<Self::Success, T::RuntimeOrigin> {
+        <T::Lookup as StaticLookup>::lookup(MultiAddress::Address20(address.0)).map_err(|_| origin)
+    }
+}

--- a/crates/humanode-runtime/src/find_author.rs
+++ b/crates/humanode-runtime/src/find_author.rs
@@ -1,8 +1,6 @@
 use core::marker::PhantomData;
 
 use frame_support::{traits::FindAuthor, ConsensusEngineId};
-use sp_application_crypto::ByteArray;
-use sp_core::H160;
 
 use crate::{AccountId, Babe, BabeId, Session};
 
@@ -31,21 +29,5 @@ impl<F: FindAuthor<Id>, Id: sp_application_crypto::AppPublic> FindAuthor<Account
     {
         let id = F::find_author(digests)?;
         Session::key_owner(Id::ID, id.as_slice())
-    }
-}
-
-pub struct FindAuthorTruncated<F>(PhantomData<F>);
-
-pub fn truncate_account_id_into_ethereum_address(account_id: AccountId) -> H160 {
-    H160::from_slice(&account_id.as_slice()[4..24])
-}
-
-impl<F: FindAuthor<AccountId>> FindAuthor<H160> for FindAuthorTruncated<F> {
-    fn find_author<'a, I>(digests: I) -> Option<H160>
-    where
-        I: 'a + IntoIterator<Item = (ConsensusEngineId, &'a [u8])>,
-    {
-        let account_id = F::find_author(digests)?;
-        Some(truncate_account_id_into_ethereum_address(account_id))
     }
 }

--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -623,9 +623,8 @@ impl pallet_evm::Config for Runtime {
     type BlockGasLimit = BlockGasLimit;
     type OnChargeTransaction = fixed_supply::EvmTransactionCharger<Balances, FeesPot>;
     type OnCreate = ();
-    type FindAuthor = find_author::FindAuthorTruncated<
-        find_author::FindAuthorFromSession<find_author::FindAuthorBabe, BabeId>,
-    >;
+    type FindAuthor =
+        evm_address::FindAuthorLookup<Self, <Self as pallet_authorship::Config>::FindAuthor>;
 }
 
 parameter_types! {

--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -603,7 +603,6 @@ parameter_types! {
     pub BlockGasLimit: U256 = U256::from(u32::max_value());
     pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::default();
     pub WeightPerGas: Weight = Weight::from_ref_time(20_000);
-    pub DefaultEvmAccountMapping: AccountId32 = AccountId32::new([0; 32]);
 }
 
 impl pallet_evm::Config for Runtime {
@@ -613,10 +612,8 @@ impl pallet_evm::Config for Runtime {
     type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
     type CallOrigin = evm_address::SystemLookupAddressOrigin<Self>;
     type WithdrawOrigin = evm_address::SystemLookupAddressOrigin<Self>;
-    type AddressMapping = evm_address::SystemLookupAddressMapping<
-        Self,
-        evm_address::StaticAddressMapping<Self, DefaultEvmAccountMapping>,
-    >;
+    type AddressMapping =
+        evm_address::SystemLookupAddressMapping<Self, evm_address::PanicAddressMapping<Self>>;
     type Currency = Balances;
     type RuntimeEvent = RuntimeEvent;
     type Runner = pallet_evm::runner::stack::Runner<Self>;

--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -37,7 +37,7 @@ use pallet_ethereum::{
     Call::transact, PostLogContent as EthereumPostLogContent, Transaction as EthereumTransaction,
 };
 use pallet_evm::FeeCalculator;
-use pallet_evm::{Account as EVMAccount, EnsureAddressTruncated, Runner};
+use pallet_evm::{Account as EVMAccount, Runner};
 use pallet_grandpa::{
     fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
@@ -61,8 +61,8 @@ pub use sp_runtime::BuildStorage;
 use sp_runtime::{
     create_runtime_str, generic, impl_opaque_keys,
     traits::{
-        AccountIdLookup, BlakeTwo256, Block as BlockT, DispatchInfoOf, Dispatchable,
-        IdentifyAccount, NumberFor, One, OpaqueKeys, PostDispatchInfoOf, StaticLookup, Verify,
+        BlakeTwo256, Block as BlockT, DispatchInfoOf, Dispatchable, IdentifyAccount, NumberFor,
+        One, OpaqueKeys, PostDispatchInfoOf, StaticLookup, Verify,
     },
     transaction_validity::{
         TransactionPriority, TransactionSource, TransactionValidity, TransactionValidityError,
@@ -75,6 +75,7 @@ use sp_std::prelude::*;
 use sp_version::NativeVersion;
 use sp_version::RuntimeVersion;
 
+pub mod evm_address;
 mod frontier_precompiles;
 mod vesting;
 use frontier_precompiles::FrontierPrecompiles;
@@ -251,7 +252,7 @@ impl frame_system::Config for Runtime {
     /// The aggregated dispatch type that is available for extrinsics.
     type RuntimeCall = RuntimeCall;
     /// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-    type Lookup = AccountIdLookup<AccountId, ()>;
+    type Lookup = evm_address::MultiLookup<Self>;
     /// The index type for storing how many extrinsics an account has signed.
     type Index = Index;
     /// The index type for blocks.
@@ -609,9 +610,8 @@ impl pallet_evm::Config for Runtime {
     type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
     type WeightPerGas = WeightPerGas;
     type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
-    type CallOrigin = EnsureAddressTruncated;
-    type WithdrawOrigin = EnsureAddressTruncated;
-    type AddressMapping = HashedAddressMapping<BlakeTwo256>;
+    type CallOrigin = evm_address::SystemLookupAddressOrigin<Self>;
+    type WithdrawOrigin = evm_address::SystemLookupAddressOrigin<Self>;
     type AddressMapping = pallet_evm::HashedAddressMapping<BlakeTwo256>;
     type Currency = Balances;
     type RuntimeEvent = RuntimeEvent;

--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -603,6 +603,7 @@ parameter_types! {
     pub BlockGasLimit: U256 = U256::from(u32::max_value());
     pub PrecompilesValue: FrontierPrecompiles<Runtime> = FrontierPrecompiles::<_>::default();
     pub WeightPerGas: Weight = Weight::from_ref_time(20_000);
+    pub DefaultEvmAccountMapping: AccountId32 = AccountId32::new([0; 32]);
 }
 
 impl pallet_evm::Config for Runtime {
@@ -612,7 +613,10 @@ impl pallet_evm::Config for Runtime {
     type BlockHashMapping = pallet_ethereum::EthereumBlockHashMapping<Self>;
     type CallOrigin = evm_address::SystemLookupAddressOrigin<Self>;
     type WithdrawOrigin = evm_address::SystemLookupAddressOrigin<Self>;
-    type AddressMapping = pallet_evm::HashedAddressMapping<BlakeTwo256>;
+    type AddressMapping = evm_address::SystemLookupAddressMapping<
+        Self,
+        evm_address::StaticAddressMapping<Self, DefaultEvmAccountMapping>,
+    >;
     type Currency = Balances;
     type RuntimeEvent = RuntimeEvent;
     type Runner = pallet_evm::runner::stack::Runner<Self>;

--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -37,7 +37,7 @@ use pallet_ethereum::{
     Call::transact, PostLogContent as EthereumPostLogContent, Transaction as EthereumTransaction,
 };
 use pallet_evm::FeeCalculator;
-use pallet_evm::{Account as EVMAccount, EnsureAddressTruncated, HashedAddressMapping, Runner};
+use pallet_evm::{Account as EVMAccount, EnsureAddressTruncated, Runner};
 use pallet_grandpa::{
     fg_primitives, AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList,
 };
@@ -612,6 +612,7 @@ impl pallet_evm::Config for Runtime {
     type CallOrigin = EnsureAddressTruncated;
     type WithdrawOrigin = EnsureAddressTruncated;
     type AddressMapping = HashedAddressMapping<BlakeTwo256>;
+    type AddressMapping = pallet_evm::HashedAddressMapping<BlakeTwo256>;
     type Currency = Balances;
     type RuntimeEvent = RuntimeEvent;
     type Runner = pallet_evm::runner::stack::Runner<Self>;

--- a/crates/humanode-runtime/src/tests/fixed_supply.rs
+++ b/crates/humanode-runtime/src/tests/fixed_supply.rs
@@ -65,6 +65,9 @@ fn new_test_ext_with() -> sp_io::TestExternalities {
         bootnodes: BootnodesConfig {
             bootnodes: bootnodes.try_into().unwrap(),
         },
+        evm_accounts_mapping: EvmAccountsMappingConfig {
+            mappings: vec![(account_id("Bob"), evm_account("Bob"))],
+        },
         ..Default::default()
     };
     let storage = config.build_storage().unwrap();
@@ -169,14 +172,14 @@ fn total_issuance_evm_withdraw() {
         // Check total issuance before making evm withdraw.
         let total_issuance_before = Balances::total_issuance();
 
-        let bob_evm = evm_truncated_address(account_id("Bob"));
-        let hashed_bob_evm =
+        let bob_evm = evm_account_h160("Bob");
+        let mapped_bob_evm =
             <Runtime as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
 
-        // Send tokens to hashed_bob_evm to make withdraw from bob_evm.
+        // Send tokens to `mapped_bob_evm` to make withdraw from `bob_evm`.
         assert_ok!(Balances::transfer(
             Some(account_id("Bob")).into(),
-            hashed_bob_evm.into(),
+            mapped_bob_evm.into(),
             INIT_BALANCE - existential_deposit - 1,
         ));
 
@@ -197,11 +200,11 @@ fn total_issuance_evm_call() {
         // Check total issuance before making evm call.
         let total_issuance_before = Balances::total_issuance();
 
-        let bob_evm = evm_truncated_address(account_id("Bob"));
+        let bob_evm = evm_account_h160("Bob");
         let hashed_bob_evm =
             <Runtime as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
 
-        // Send tokens to hashed_bob_evm to make call from bob_evm.
+        // Send tokens to `mapped_bob_evm` to make call from `bob_evm`.
         assert_ok!(Balances::transfer(
             Some(account_id("Bob")).into(),
             hashed_bob_evm.into(),
@@ -236,14 +239,14 @@ fn total_issuance_evm_create() {
         // Check total issuance before making evm create.
         let total_issuance_before = Balances::total_issuance();
 
-        let bob_evm = evm_truncated_address(account_id("Bob"));
-        let hashed_bob_evm =
+        let bob_evm = evm_account_h160("Bob");
+        let mapped_bob_evm =
             <Runtime as pallet_evm::Config>::AddressMapping::into_account_id(bob_evm);
 
-        // Send tokens to hashed_bob_evm to make create from bob_evm.
+        // Send tokens to `mapped_bob_evm` to make create from `bob_evm`.
         assert_ok!(Balances::transfer(
             Some(account_id("Bob")).into(),
-            hashed_bob_evm.into(),
+            mapped_bob_evm.into(),
             INIT_BALANCE - existential_deposit - 1,
         ));
 


### PR DESCRIPTION
This PR updates the EVM account mapping logic to take the EVM account mappings into account.

---

To do:

- [x] `frame_system::Config::Lookup` is made to use the mapping
- [x] `pallet_evm::Config::CallOrigin` and `pallet_evm::Config::WithdrawOrigin` is made to use the system lookup
- ~use a fallible EVM to make the address lookups fallible in the EVM internals~ postpone it to a separate PR
- [x] ~set the `pallet_evm::Config::AddressMapping` to the fallible lookup logic via the mapping~ we won't have a fallible EVM at this PR, so postpone this too; instead, we have implemented a fallback to the wrapped eth 20-byte address in the "native" `AccountId32`; see #659
- [x] tweak `pallet_evm::Config::FindAuthor` accordingly
- [x] tweak `pallet_evm::Config::OnChargeTransaction` to handle the tips same way we handle the tips
- ~~extract the implementation into a separate crate (or not?)~~ we will leave this as is for now, and refactor the runtime later when we dedicate the time specifically for it
- [ ] implement the tests with a mock runtime