### PR TITLE
Correct the benchmarking dependencies of the runtime

### DIFF
--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -47,7 +47,7 @@ frame-system-benchmarking = { default-features = false, optional = true, git = "
 frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/humanode-network/substrate", branch = "master" }
 frame-try-runtime = { default-features = false, optional = true, git = "https://github.com/humanode-network/substrate", branch = "master" }
 hex-literal = { version = "0.3", optional = true }
-libsecp256k1 = { version = "0.7.0", default-features = false }
+libsecp256k1 = { version = "0.7.0", features = ["hmac", "static-context"], optional = true }
 pallet-authorship = { default-features = false, git = "https://github.com/humanode-network/substrate", branch = "master" }
 pallet-babe = { default-features = false, git = "https://github.com/humanode-network/substrate", branch = "master" }
 pallet-balances = { default-features = false, git = "https://github.com/humanode-network/substrate", branch = "master" }
@@ -107,8 +107,7 @@ runtime-benchmarks = [
   "pallet-token-claims/runtime-benchmarks",
   "pallet-vesting/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
-  "libsecp256k1/hmac",
-  "libsecp256k1/static-context",
+  "libsecp256k1",
 ]
 std = [
   "author-ext-api/std",


### PR DESCRIPTION
<details>

After we merged #441 I noticed the `cargo run -- --dev` fails with an odd error:

```
Cannot create a runtime error=Other("runtime requires function imports which are not present on the host: 'env:ext_benchmarking_reset_read_write_count_version_1', 'env:ext_benchmarking_get_read_and_written_keys_version_1', 'env:ext_benchmarking_set_whitelist_version_1', 'env:ext_benchmarking_proof_size_version_1', 'env:ext_benchmarking_wipe_db_version_1', 'env:ext_benchmarking_read_write_count_version_1', 'env:ext_benchmarking_commit_db_version_1', 'env:ext_benchmarking_current_time_version_1', 'env:ext_benchmarking_add_to_whitelist_version_1'")
```

Investigating led me to this fix, which makes `cargo run -- --dev` work. Not sure why it is breaking without it. Might be some issue with caching of the build artifacts on my local system, idk.

</details>

---

Still, regardless of the above, this PR actually removes one dependency when we're not in the benchmarking mode.