### PR TITLE
Tweak the bioauth limits at runtime

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -186,13 +186,13 @@ pub const EPOCH_DURATION_IN_SLOTS: u64 = {
 const REPORT_LONGEVITY: u64 = 3 * EPOCH_DURATION_IN_BLOCKS as u64;
 
 // Consensus related constants.
-pub const MAX_AUTHENTICATIONS: u32 = 20 * 1024;
+pub const MAX_AUTHENTICATIONS: u32 = 3 * 1024;
 pub const MAX_AUTHORITIES: u32 = MAX_AUTHENTICATIONS;
-pub const MAX_NONCES: u32 = 2000 * MAX_AUTHENTICATIONS;
+pub const MAX_NONCES: u32 = 10000 * MAX_AUTHENTICATIONS;
 
 // ImOnline related constants.
 // TODO(#311): set proper values
-pub const MAX_KEYS: u32 = 20 * 1024;
+pub const MAX_KEYS: u32 = 10 * 1024;
 pub const MAX_PEER_IN_HEARTBEATS: u32 = 3 * MAX_KEYS;
 pub const MAX_PEER_DATA_ENCODING_SIZE: u32 = 1_000;
 


### PR DESCRIPTION
In preparation to it5 and, ultimately, mainnet, this PR tweaks the values to be more reasonable.

Refs:
- https://grafana.scw.cloud.humanode.io/d/humanode-chain-dashboard/humanode-chain-dashboard-vendored?orgId=1&var-datasource=Prometheus&var-namespace=testnet4&var-interval=$__auto_interval_interval
- https://telemetry.humanode.io/#list/0xb10e573169aaaa74d14931e98d414a8a631dd3bc6dda31101061ed3b7c2cb343