### PR TITLE
Update FaceTec match level

### DIFF
--- a/crates/robonode-server/src/logic/op_authenticate.rs
+++ b/crates/robonode-server/src/logic/op_authenticate.rs
@@ -157,7 +157,7 @@ where
         // If the results set is empty - this means that this person was not
         // found in the system.
         let found = results.first().ok_or(Error::PersonNotFound)?;
-        if found.match_level != MATCH_LEVEL {
+        if found.match_level < MATCH_LEVEL {
             return Err(Error::InternalErrorDbSearchMatchLevelMismatch);
         }
 


### PR DESCRIPTION
New FaceTec server has a few updates:
| | Before | After |
| --- | --- | --- |
| Maximum `min_match_level` in `/3d-db/search` | 10 | 10 |
| Maximum `match_level` in search results | 10 | 15 |

So, we should leave `MATCH_LEVEL` constant as is and change the approach in search results.