### PR TITLE
Remove unused `PositiveImbalanceOf` at `pallet-pot`

### DIFF
--- a/crates/pallet-pot/src/lib.rs
+++ b/crates/pallet-pot/src/lib.rs
@@ -17,11 +17,6 @@ const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 pub type BalanceOf<T, I = ()> =
     <<T as Config<I>>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
-/// The positive imbalance accessor.
-pub type PositiveImbalanceOf<T, I = ()> = <<T as Config<I>>::Currency as Currency<
-    <T as frame_system::Config>::AccountId,
->>::PositiveImbalance;
-
 /// The negative implanace accessor.
 pub type NegativeImbalanceOf<T, I = ()> = <<T as Config<I>>::Currency as Currency<
     <T as frame_system::Config>::AccountId,


### PR DESCRIPTION
Based on https://skyharbor.certik.com/report/34dc4ecb-4776-4bf3-9750-b3f0d60c3efc?findingIndex=1669395694321