### PR TITLE
Consistent flags for bioauth subcommands `InsertKeyCmd` and `InspectKeyCmd`

### DIFF
--- a/crates/humanode-peer/src/cli/subcommand/bioauth/key/insert.rs
+++ b/crates/humanode-peer/src/cli/subcommand/bioauth/key/insert.rs
@@ -15,7 +15,7 @@ use crate::cli::CliConfigurationExt;
 #[derive(Debug, clap::Parser)]
 pub struct InsertKeyCmd {
     /// The secret key uri (mnemonic).
-    #[arg(long)]
+    #[arg(long, short = 'm')]
     pub suri: String,
 
     #[allow(missing_docs, clippy::missing_docs_in_private_items)]


### PR DESCRIPTION
Based on https://skyharbor.certik.com/report/34dc4ecb-4776-4bf3-9750-b3f0d60c3efc?findingIndex=1669037983349