### PR TITLE
Change default period for era at `create_transaction` at runtime

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -789,8 +789,9 @@ impl frame_system::offchain::CreateSignedTransaction<RuntimeCall> for Runtime {
         <UncheckedExtrinsic as sp_runtime::traits::Extrinsic>::SignaturePayload,
     )> {
         let tip = 0;
-        // Take the biggest period possible. In case of having overflow,
-        // will use 0 as `sp_runtime::generic::Era::mortal` claps the value where lower bound is 4.
+        // Take the biggest period possible, considering the number of cached block hashes.
+        // In case of overflow we pass default (`0`) and let `sp_runtime::generic::Era::mortal`
+        // clamp the value to the appropriate lower bound.
         let period = <Self::BlockHashCount as Get<Self::BlockNumber>>::get()
             .checked_next_power_of_two()
             .map(|c| c / 2)


### PR DESCRIPTION
Based on discussion - https://skyharbor.certik.com/report/56725e92-d24e-42dc-ad1c-801fd0f73974?findingIndex=LIH-03

My bad, I was thinking that `checked_next_power_of_two()` returns a new value but it actually returns its input if it is already a power of two.