### PR TITLE
Optimize the use of substrate WASM builder

### DIFF
--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -5,8 +5,7 @@ edition = "2021"
 publish = false
 
 [build-dependencies]
-# See https://github.com/paritytech/substrate/pull/10284
-substrate-wasm-builder = { git = "https://github.com/humanode-network/substrate", branch = "locked/polkadot-v0.9.36" }
+substrate-wasm-builder = { git = "https://github.com/humanode-network/substrate", branch = "locked/polkadot-v0.9.36", optional = true }
 
 [dependencies]
 author-ext-api = { version = "0.1", path = "../author-ext-api", default-features = false }
@@ -194,6 +193,7 @@ std = [
   "sp-tracing/std",
   "sp-transaction-pool/std",
   "sp-version/std",
+  "substrate-wasm-builder",
   "vesting-schedule-linear/std",
   "vesting-scheduling-timestamp/std",
 ]

--- a/crates/humanode-runtime/build.rs
+++ b/crates/humanode-runtime/build.rs
@@ -4,12 +4,13 @@
 //! and embedded WASM blob for the native build.
 //! It is transparent, is a sense that you won't notice if everything works out.
 
-use substrate_wasm_builder::WasmBuilder;
-
 fn main() {
-    WasmBuilder::new()
-        .with_current_project()
-        .import_memory()
-        .export_heap_base()
-        .build()
+    #[cfg(feature = "std")]
+    {
+        substrate_wasm_builder::WasmBuilder::new()
+            .with_current_project()
+            .import_memory()
+            .export_heap_base()
+            .build()
+    }
 }


### PR DESCRIPTION
In theory, this should reduce the side of the `target` build artifacts dir, which should reduce the size of CI build caches, which, in turn, will make them fit in the space we have for the caches, which will make it so that caches are not evicted this often, which will make caches available to the CI builds more time than before, which will make builds faster. So we wait less.