### PR TITLE
Add external account id type for `pallet-pot`

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -401,18 +401,21 @@ type PotInstanceTokenClaims = pallet_pot::Instance3;
 
 impl pallet_pot::Config<PotInstanceTreasury> for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type AccountId = AccountId;
     type PalletId = TreasuryPotPalletId;
     type Currency = Balances;
 }
 
 impl pallet_pot::Config<PotInstanceFees> for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type AccountId = AccountId;
     type PalletId = FeesPotPalletId;
     type Currency = Balances;
 }
 
 impl pallet_pot::Config<PotInstanceTokenClaims> for Runtime {
     type RuntimeEvent = RuntimeEvent;
+    type AccountId = AccountId;
     type PalletId = TokenClaimsPotPalletId;
     type Currency = Balances;
 }

--- a/crates/pallet-pot/src/lib.rs
+++ b/crates/pallet-pot/src/lib.rs
@@ -8,7 +8,7 @@
 use frame_support::traits::{Imbalance, OnUnbalanced, StorageVersion};
 use frame_support::{pallet_prelude::*, traits::Currency, PalletId};
 use frame_system::pallet_prelude::*;
-use sp_runtime::traits::{AccountIdConversion, CheckedSub, Saturating};
+use sp_runtime::traits::{AccountIdConversion, CheckedSub, MaybeDisplay, Saturating};
 
 pub use self::pallet::*;
 
@@ -17,12 +17,11 @@ const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
 /// The balance of accessor for the currency.
 pub type BalanceOf<T, I = ()> =
-    <<T as Config<I>>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
+    <<T as Config<I>>::Currency as Currency<<T as Config<I>>::AccountId>>::Balance;
 
 /// The negative implanace accessor.
-pub type NegativeImbalanceOf<T, I = ()> = <<T as Config<I>>::Currency as Currency<
-    <T as frame_system::Config>::AccountId,
->>::NegativeImbalance;
+pub type NegativeImbalanceOf<T, I = ()> =
+    <<T as Config<I>>::Currency as Currency<<T as Config<I>>::AccountId>>::NegativeImbalance;
 
 /// The initial state of the pot, for use in genesis.
 #[cfg(feature = "std")]
@@ -44,6 +43,8 @@ pub enum InitialState<Balance> {
 #[allow(clippy::missing_docs_in_private_items)]
 #[frame_support::pallet]
 pub mod pallet {
+    use sp_std::fmt::Debug;
+
     use super::*;
 
     /// Configure the pallet by specifying the parameters and types on which it depends.
@@ -53,8 +54,17 @@ pub mod pallet {
         type RuntimeEvent: From<Event<Self, I>>
             + IsType<<Self as frame_system::Config>::RuntimeEvent>;
 
+        /// The user account identifier type.
+        type AccountId: Parameter
+            + Member
+            + MaybeSerializeDeserialize
+            + Debug
+            + MaybeDisplay
+            + Ord
+            + MaxEncodedLen;
+
         /// The currency to operate with.
-        type Currency: Currency<Self::AccountId>;
+        type Currency: Currency<<Self as Config<I>>::AccountId>;
 
         /// The pot's pallet id, used for deriving its sovereign account ID.
         #[pallet::constant]
@@ -68,7 +78,7 @@ pub mod pallet {
         /// This actually performs computation.
         /// If you need to keep using it, then make sure you cache the value and
         /// only call this once.
-        pub fn account_id() -> T::AccountId {
+        pub fn account_id() -> <T as Config<I>>::AccountId {
             T::PalletId::get().into_account_truncating()
         }
     }

--- a/crates/pallet-token-claims/src/mock.rs
+++ b/crates/pallet-token-claims/src/mock.rs
@@ -82,6 +82,7 @@ parameter_types! {
 
 impl pallet_pot::Config for Test {
     type RuntimeEvent = RuntimeEvent;
+    type AccountId = u64;
     type Currency = Balances;
     type PalletId = PotPalletId;
 }


### PR DESCRIPTION
As a part of separating balances between native accounts and evm accounts. 
We need a separate `EvmFeesPot` account to collect fees from evm transactions.