### PR TITLE
End-to-end EVM fee test

### DIFF
--- a/utils/e2e-tests/ts/lib/eth.ts
+++ b/utils/e2e-tests/ts/lib/eth.ts
@@ -13,11 +13,13 @@ export const providerFromNode = (node: RunNodeState): Provider =>
 export const SUBSTRATE_DEV_SEED_PHRASE =
   "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
 
+export const ROOT_DEV_ACCOUNT_DERIVATION_PATH = "m/44'/60'/0'/0" as const;
+
 export const DEV_ACCOUNT_INDICIES = [0, 1] as const;
 
 export const devHDNodeWalletRoot = HDNodeWallet.fromMnemonic(
   Mnemonic.fromPhrase(SUBSTRATE_DEV_SEED_PHRASE),
-  "m/44'/60'/0'/0"
+  ROOT_DEV_ACCOUNT_DERIVATION_PATH
 );
 
 export const devHDNodeWallets = arrayMap(DEV_ACCOUNT_INDICIES, (accountIndex) =>

--- a/utils/e2e-tests/ts/lib/eth.ts
+++ b/utils/e2e-tests/ts/lib/eth.ts
@@ -1,5 +1,6 @@
-import { ethers } from "ethers";
+import { HDNodeWallet, ethers, Mnemonic, Wallet } from "ethers";
 import { RunNodeState } from "./node";
+import { arrayMap } from "./jsbase";
 
 export type Provider = ethers.JsonRpcProvider;
 
@@ -8,3 +9,25 @@ export const provider = (url: string): Provider =>
 
 export const providerFromNode = (node: RunNodeState): Provider =>
   provider(node.meta.rpcUrlHttp);
+
+export const SUBSTRATE_DEV_SEED_PHRASE =
+  "bottom drive obey lake curtain smoke basket hold race lonely fit walk";
+
+export const DEV_ACCOUNT_INDICIES = [0, 1] as const;
+
+export const devHDNodeWalletRoot = HDNodeWallet.fromMnemonic(
+  Mnemonic.fromPhrase(SUBSTRATE_DEV_SEED_PHRASE),
+  "m/44'/60'/0'/0"
+);
+
+export const devHDNodeWallets = arrayMap(DEV_ACCOUNT_INDICIES, (accountIndex) =>
+  devHDNodeWalletRoot.deriveChild(accountIndex)
+);
+
+export const devSigners = (provider: Provider) =>
+  arrayMap(
+    devHDNodeWallets,
+    (hdnodeWallet) => new Wallet(hdnodeWallet.privateKey, provider)
+  );
+
+export type DevSigners = ReturnType<typeof devSigners>;

--- a/utils/e2e-tests/ts/lib/expect.ts
+++ b/utils/e2e-tests/ts/lib/expect.ts
@@ -1,0 +1,25 @@
+import { expect } from "vitest";
+import type { RawMatcherFn } from "@vitest/expect";
+
+interface CustomMatchers<R = unknown> extends RawMatcherFn {
+  toBeWithin(value: R & bigint, options: { tolerance: bigint }): R;
+}
+
+expect.extend({
+  toBeWithin(received, expected, { tolerance }) {
+    const { isNot } = this;
+    return {
+      // do not alter your "pass" based on isNot. Vitest does it for you
+      pass: received > expected - tolerance && received < expected + tolerance,
+      message: () =>
+        `${received} is${
+          !isNot ? " not" : ""
+        } within ${tolerance} of ${expected}`,
+    };
+  },
+});
+
+declare module "vitest" {
+  interface Assertion<T = any> extends CustomMatchers<T> {}
+  interface AsymmetricMatchersContaining extends CustomMatchers {}
+}

--- a/utils/e2e-tests/ts/lib/jsbase.ts
+++ b/utils/e2e-tests/ts/lib/jsbase.ts
@@ -1,0 +1,33 @@
+export type ArrayMapFn<
+  T extends readonly any[],
+  Index extends keyof T,
+  Result
+> = (item: T[Index], index: Index, src: T) => Result;
+
+export type ArrayMapResult<
+  T extends readonly any[],
+  F extends ArrayMapFn<T, any, any>
+> = {
+  [K in keyof T]: F extends ArrayMapFn<T, K, infer R> ? R : never;
+};
+
+export function arrayMap<
+  const T extends readonly any[],
+  const F extends ArrayMapFn<T, any, any>
+>(array: T, fn: F): ArrayMapResult<T, F> {
+  return array.map(fn as any) as ArrayMapResult<T, F>;
+}
+
+export function objectKeysMap<
+  const T extends { [Keys in any]: any },
+  F extends ArrayMapFn<(keyof T)[], any, any>
+>(object: T, fn: F): ArrayMapResult<(keyof T)[], F> {
+  return arrayMap(Object.keys(object) as (keyof T)[], fn);
+}
+
+export function objectValuesMap<
+  const T extends { [Keys in any]: any },
+  F extends ArrayMapFn<T[keyof T][], any, any>
+>(object: T, fn: F): ArrayMapResult<T[keyof T][], F> {
+  return arrayMap(Object.values(object) as T[keyof T][], fn);
+}

--- a/utils/e2e-tests/ts/package.json
+++ b/utils/e2e-tests/ts/package.json
@@ -10,6 +10,7 @@
   "dependencies": {
     "@polkadot/api": "^10.9.1",
     "@types/node": "16.18.39",
+    "@vitest/expect": "^0.34.1",
     "axios": "^1.4.0",
     "ethers": "^6.7.0",
     "typescript": "^5.1.6",

--- a/utils/e2e-tests/ts/tests/rpc/eth.ts
+++ b/utils/e2e-tests/ts/tests/rpc/eth.ts
@@ -29,7 +29,7 @@ describe("eth rpc", () => {
   });
 
   describe("fee", () => {
-    describe("when transfering 1 eHMND", () => {
+    describe("when transferring 1 eHMND", () => {
       const transferValue = ethers.parseEther("1");
       const expectedFee = ethers.parseEther("0.00004"); // TODO: adjust this to a real value of 0.2
       const tolerance = expectedFee / 10n;

--- a/utils/e2e-tests/ts/tests/rpc/eth.ts
+++ b/utils/e2e-tests/ts/tests/rpc/eth.ts
@@ -3,6 +3,7 @@ import { RunNodeState, runNode } from "../../lib/node";
 import * as eth from "../../lib/eth";
 import { cleanupStack } from "../../lib/cleanup";
 import * as ethers from "ethers";
+import "../../lib/expect";
 
 describe("eth rpc", () => {
   let node: RunNodeState;
@@ -46,9 +47,7 @@ describe("eth rpc", () => {
 
         console.log({ actual: fee, expected: expectedFee, tolerance });
 
-        expect(
-          fee > expectedFee - tolerance && fee < expectedFee + tolerance
-        ).toStrictEqual(true);
+        expect(fee).toBeWithin(expectedFee, { tolerance });
       });
     });
   });

--- a/utils/e2e-tests/ts/tests/rpc/eth.ts
+++ b/utils/e2e-tests/ts/tests/rpc/eth.ts
@@ -45,8 +45,6 @@ describe("eth rpc", () => {
         const txReceipt = await tx.wait(1, 12000);
         const fee = txReceipt!.fee;
 
-        console.log({ actual: fee, expected: expectedFee, tolerance });
-
         expect(fee).toBeWithin(expectedFee, { tolerance });
       });
     });

--- a/utils/e2e-tests/ts/tests/rpc/eth.ts
+++ b/utils/e2e-tests/ts/tests/rpc/eth.ts
@@ -2,10 +2,12 @@ import { expect, describe, beforeEach, it } from "vitest";
 import { RunNodeState, runNode } from "../../lib/node";
 import * as eth from "../../lib/eth";
 import { cleanupStack } from "../../lib/cleanup";
+import * as ethers from "ethers";
 
 describe("eth rpc", () => {
   let node: RunNodeState;
   let provider: eth.Provider;
+  let devSigners: eth.DevSigners;
   beforeEach(async () => {
     const cleanup = cleanupStack();
 
@@ -15,6 +17,7 @@ describe("eth rpc", () => {
     await node.waitForBoot;
 
     provider = eth.providerFromNode(node);
+    devSigners = eth.devSigners(provider);
 
     return cleanup.run;
   }, 60 * 1000);
@@ -22,5 +25,31 @@ describe("eth rpc", () => {
   it("has the expected Chain ID", async () => {
     const network = await provider.getNetwork();
     expect(network.chainId).toBe(5234n);
+  });
+
+  describe("fee", () => {
+    describe("when transfering 1 eHMND", () => {
+      const transferValue = ethers.parseEther("1");
+      const expectedFee = ethers.parseEther("0.1");
+      const tolerance = ethers.parseEther("0.01");
+
+      it("changes the balance within the tolerance around the expected cost", async () => {
+        const [alice, bob] = devSigners;
+
+        const tx = await alice.sendTransaction({
+          to: bob.address,
+          value: transferValue,
+        });
+
+        const txReceipt = await tx.wait(1, 12000);
+        const fee = txReceipt!.fee;
+
+        console.log({ actual: fee, expected: expectedFee, tolerance });
+
+        expect(
+          fee > expectedFee - tolerance && fee < expectedFee + tolerance
+        ).toStrictEqual(true);
+      });
+    });
   });
 });

--- a/utils/e2e-tests/ts/tests/rpc/eth.ts
+++ b/utils/e2e-tests/ts/tests/rpc/eth.ts
@@ -31,8 +31,8 @@ describe("eth rpc", () => {
   describe("fee", () => {
     describe("when transfering 1 eHMND", () => {
       const transferValue = ethers.parseEther("1");
-      const expectedFee = ethers.parseEther("0.1");
-      const tolerance = ethers.parseEther("0.01");
+      const expectedFee = ethers.parseEther("0.00004"); // TODO: adjust this to a real value of 0.2
+      const tolerance = expectedFee / 10n;
 
       it("changes the balance within the tolerance around the expected cost", async () => {
         const [alice, bob] = devSigners;

--- a/utils/e2e-tests/ts/tests/rpc/eth.ts
+++ b/utils/e2e-tests/ts/tests/rpc/eth.ts
@@ -34,7 +34,7 @@ describe("eth rpc", () => {
       const expectedFee = ethers.parseEther("0.00004"); // TODO: adjust this to a real value of 0.2
       const tolerance = expectedFee / 10n;
 
-      it("changes the balance within the tolerance around the expected cost", async () => {
+      it("is within the tolerance around the expected cost", async () => {
         const [alice, bob] = devSigners;
 
         const tx = await alice.sendTransaction({

--- a/utils/e2e-tests/ts/vitest.config.ts
+++ b/utils/e2e-tests/ts/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
     watch: false,
     threads: false,
     singleThread: true,
+    testTimeout: 30_000,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,7 +762,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vitest/expect@npm:0.34.1":
+"@vitest/expect@npm:0.34.1, @vitest/expect@npm:^0.34.1":
   version: 0.34.1
   resolution: "@vitest/expect@npm:0.34.1"
   dependencies:
@@ -1549,6 +1549,7 @@ __metadata:
   dependencies:
     "@polkadot/api": ^10.9.1
     "@types/node": 16.18.39
+    "@vitest/expect": ^0.34.1
     axios: ^1.4.0
     ethers: ^6.7.0
     typescript: ^5.1.6


### PR DESCRIPTION
This PR adds a simple test for the basic transaction fee with our node. For now, I have set it to expect the current value, but once we implement proper EVM fee tweaks the expectation value will be adjusted to its real target value.

In addition, this PR also adds some crucial type-safety utils that the standard TypeScript lacks.

It also sets the basis for conducting tests with EVM dev accounts in the E2E tests.