### PR TITLE
Allow using dev seeds at the evm cli command

### DIFF
--- a/crates/humanode-peer/src/cli/subcommand/evm/generate.rs
+++ b/crates/humanode-peer/src/cli/subcommand/evm/generate.rs
@@ -24,7 +24,7 @@ impl GenerateAccountCmd {
             false => Mnemonic::new(MnemonicType::Words12, Language::English),
         };
 
-        extract_and_print_keys(&mnemonic, self.account_index)
+        extract_and_print_keys(Some(&mnemonic), self.account_index)
             .map_err(|err| sc_cli::Error::Application(Box::new(err)))?;
 
         Ok(())

--- a/crates/humanode-peer/src/cli/subcommand/evm/inspect.rs
+++ b/crates/humanode-peer/src/cli/subcommand/evm/inspect.rs
@@ -9,7 +9,7 @@ use super::utils::extract_and_print_keys;
 pub struct InspectAccountCmd {
     /// Specify the mnemonic.
     #[arg(long, short = 'm')]
-    mnemonic: String,
+    mnemonic: Option<String>,
 
     /// The account index to use in the derivation path.
     #[arg(long = "account-index", short = 'a')]
@@ -19,10 +19,16 @@ pub struct InspectAccountCmd {
 impl InspectAccountCmd {
     /// Run the inspect command.
     pub async fn run(&self) -> sc_cli::Result<()> {
-        let mnemonic = Mnemonic::from_phrase(&self.mnemonic, Language::English)
-            .map_err(|err| sc_cli::Error::Input(err.to_string()))?;
+        let mnemonic = self
+            .mnemonic
+            .as_ref()
+            .map(|mnemonic| {
+                Mnemonic::from_phrase(mnemonic, Language::English)
+                    .map_err(|err| sc_cli::Error::Input(err.to_string()))
+            })
+            .transpose()?;
 
-        extract_and_print_keys(&mnemonic, self.account_index)
+        extract_and_print_keys(mnemonic.as_ref(), self.account_index)
             .map_err(|err| sc_cli::Error::Application(Box::new(err)))?;
 
         Ok(())

--- a/crates/humanode-peer/src/cli/subcommand/evm/inspect.rs
+++ b/crates/humanode-peer/src/cli/subcommand/evm/inspect.rs
@@ -22,11 +22,9 @@ impl InspectAccountCmd {
         let mnemonic = self
             .mnemonic
             .as_ref()
-            .map(|mnemonic| {
-                Mnemonic::from_phrase(mnemonic, Language::English)
-                    .map_err(|err| sc_cli::Error::Input(err.to_string()))
-            })
-            .transpose()?;
+            .map(|mnemonic| Mnemonic::from_phrase(mnemonic, Language::English))
+            .transpose()
+            .map_err(|err| sc_cli::Error::Input(err.to_string()))?;
 
         extract_and_print_keys(mnemonic.as_ref(), self.account_index)
             .map_err(|err| sc_cli::Error::Application(Box::new(err)))?;

--- a/crates/humanode-peer/src/cli/subcommand/evm/inspect.rs
+++ b/crates/humanode-peer/src/cli/subcommand/evm/inspect.rs
@@ -4,12 +4,25 @@ use bip39::{Language, Mnemonic};
 
 use super::utils::extract_and_print_keys;
 
-/// The `ethereum inspect` command.
-#[derive(Debug, clap::Parser)]
-pub struct InspectAccountCmd {
+/// The mnemonic input.
+#[derive(Debug, clap::Args)]
+#[group(required = true, multiple = false)]
+pub struct MnemonicInput {
     /// Specify the mnemonic.
     #[arg(long, short = 'm')]
     mnemonic: Option<String>,
+
+    /// Use the built-in dev mnemonic.
+    #[arg(long, short = 'd')]
+    dev: bool,
+}
+
+/// The `ethereum inspect` command.
+#[derive(Debug, clap::Parser)]
+pub struct InspectAccountCmd {
+    /// The mnemonic input.
+    #[command(flatten)]
+    pub mnemonic_input: MnemonicInput,
 
     /// The account index to use in the derivation path.
     #[arg(long = "account-index", short = 'a')]
@@ -19,9 +32,9 @@ pub struct InspectAccountCmd {
 impl InspectAccountCmd {
     /// Run the inspect command.
     pub async fn run(&self) -> sc_cli::Result<()> {
-        let mnemonic = self
-            .mnemonic
-            .as_ref()
+        let mnemonic = self.mnemonic_input.mnemonic.as_ref();
+
+        let mnemonic = mnemonic
             .map(|mnemonic| Mnemonic::from_phrase(mnemonic, Language::English))
             .transpose()
             .map_err(|err| sc_cli::Error::Input(err.to_string()))?;

--- a/crates/humanode-peer/src/cli/subcommand/evm/utils.rs
+++ b/crates/humanode-peer/src/cli/subcommand/evm/utils.rs
@@ -1,11 +1,17 @@
 //! Common utils to process ethereum keys.
 
-/// A helper function to extract and print keys based on provided mnemonic.
+/// A helper function to extract and print keys based on provided mnemonic or the dev mnemonic
+/// if none was provided.
 pub fn extract_and_print_keys(
-    mnemonic: &bip39::Mnemonic,
+    mnemonic: Option<&bip39::Mnemonic>,
     account_index: Option<u32>,
 ) -> Result<(), crypto_utils_evm::FromMnemonicBip44Error> {
-    let key_data = crypto_utils_evm::KeyData::from_mnemonic_bip44(mnemonic, "", account_index)?;
+    let key_data = match mnemonic {
+        Some(mnemonic) => {
+            crypto_utils_evm::KeyData::from_mnemonic_bip44(mnemonic, "", account_index)?
+        }
+        None => crypto_utils_evm::KeyData::from_dev_seed(account_index.unwrap_or(0)),
+    };
 
     println!("Address:      {:?}", key_data.account);
     println!("Mnemonic:     {}", key_data.mnemonic);


### PR DESCRIPTION
This is a small UX improvement for those who would like to run the node in the `--dev` mode.