### PR TITLE
Update rust to nightly-2023-03-04

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6918,9 +6918,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/ngrok-api/src/client.rs
+++ b/crates/ngrok-api/src/client.rs
@@ -61,7 +61,7 @@ impl Client {
             .json(req)
             .send()
             .await?;
-        self.check_response::<Request>(&res)?;
+        self.check_response(&res)?;
         let res: response::Envelope<Request::Response> = res.json().await?;
         Ok(res.payload)
     }
@@ -84,7 +84,7 @@ impl Client {
     }
 
     /// Check the response.
-    fn check_response<Request>(&self, res: &reqwest::Response) -> Result<(), Error> {
+    fn check_response(&self, res: &reqwest::Response) -> Result<(), Error> {
         let status = res.status();
         if !status.is_success() {
             return Err(Error::BadStatus(status));

--- a/crates/pallet-token-claims/src/tests.rs
+++ b/crates/pallet-token-claims/src/tests.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 fn pot_account_balance() -> BalanceOf<Test> {
-    <CurrencyOf<Test>>::free_balance(&<Test as Config>::PotAccountId::get())
+    <CurrencyOf<Test>>::free_balance(<Test as Config>::PotAccountId::get())
 }
 
 fn total_claimable_balance() -> BalanceOf<Test> {

--- a/crates/pallet-vesting/src/tests.rs
+++ b/crates/pallet-vesting/src/tests.rs
@@ -20,8 +20,8 @@ fn lock_under_vesting_works() {
 
         // Check test preconditions.
         assert!(<Schedules<Test>>::get(42).is_none());
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -39,8 +39,8 @@ fn lock_under_vesting_works() {
         assert_ok!(Vesting::lock_under_vesting(&42, MockSchedule));
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
         assert!(<Schedules<Test>>::get(42).is_some());
         assert_eq!(System::events().len(), 2);
         System::assert_has_event(mock::RuntimeEvent::Vesting(Event::Locked {
@@ -67,8 +67,8 @@ fn lock_under_vesting_works_with_zero() {
 
         // Check test preconditions.
         assert!(<Schedules<Test>>::get(42).is_none());
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -86,8 +86,8 @@ fn lock_under_vesting_works_with_zero() {
         assert_ok!(Vesting::lock_under_vesting(&42, MockSchedule));
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
         assert!(<Schedules<Test>>::get(42).is_none());
         assert_eq!(System::events().len(), 2);
         System::assert_has_event(mock::RuntimeEvent::Vesting(Event::Locked {
@@ -116,8 +116,8 @@ fn lock_under_vesting_conflicts_with_existing_lock() {
 
         // Check test preconditions.
         let schedule_before = <Schedules<Test>>::get(42).unwrap();
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -134,8 +134,8 @@ fn lock_under_vesting_conflicts_with_existing_lock() {
         );
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
         assert_eq!(<Schedules<Test>>::get(42).unwrap(), schedule_before);
         assert_eq!(System::events().len(), 0);
 
@@ -156,8 +156,8 @@ fn lock_under_vesting_can_lock_balance_greater_than_free_balance() {
 
         // Check test preconditions.
         assert!(<Schedules<Test>>::get(42).is_none());
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -175,8 +175,8 @@ fn lock_under_vesting_can_lock_balance_greater_than_free_balance() {
         assert_ok!(Vesting::lock_under_vesting(&42, MockSchedule));
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 0);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 0);
         assert!(<Schedules<Test>>::get(42).is_some());
         assert_eq!(System::events().len(), 2);
         System::assert_has_event(mock::RuntimeEvent::Vesting(Event::Locked {
@@ -206,8 +206,8 @@ fn unlock_works_full() {
 
         // Check test preconditions.
         assert!(<Schedules<Test>>::get(42).is_some());
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -225,8 +225,8 @@ fn unlock_works_full() {
         assert_ok!(Vesting::unlock(RuntimeOrigin::signed(42)));
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
         assert!(<Schedules<Test>>::get(42).is_none());
         assert_eq!(System::events().len(), 1);
         System::assert_has_event(mock::RuntimeEvent::Vesting(Event::FullyUnlocked {
@@ -250,8 +250,8 @@ fn unlock_works_partial() {
 
         // Check test preconditions.
         let schedule_before = <Schedules<Test>>::get(42).unwrap();
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -269,8 +269,8 @@ fn unlock_works_partial() {
         assert_ok!(Vesting::unlock(RuntimeOrigin::signed(42)));
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 910);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 910);
         assert_eq!(<Schedules<Test>>::get(42).unwrap(), schedule_before);
         assert_eq!(System::events().len(), 1);
         System::assert_has_event(mock::RuntimeEvent::Vesting(Event::PartiallyUnlocked {
@@ -295,8 +295,8 @@ fn unlock_computation_failure() {
 
         // Check test preconditions.
         let schedule_before = <Schedules<Test>>::get(42).unwrap();
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -317,8 +317,8 @@ fn unlock_computation_failure() {
         );
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
         assert_eq!(<Schedules<Test>>::get(42).unwrap(), schedule_before);
         assert_eq!(System::events().len(), 0);
 
@@ -337,8 +337,8 @@ fn unlock_no_vesting_error() {
 
         // Check test preconditions.
         assert!(<Schedules<Test>>::get(42).is_none());
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -355,8 +355,8 @@ fn unlock_no_vesting_error() {
         );
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
         assert!(<Schedules<Test>>::get(42).is_none());
         assert_eq!(System::events().len(), 0);
 
@@ -376,8 +376,8 @@ fn update_vesting_works_partial_unlock() {
 
         // Check test preconditions.
         assert!(<Schedules<Test>>::get(42).is_some());
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -399,8 +399,8 @@ fn update_vesting_works_partial_unlock() {
         ));
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 950);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 950);
         assert!(<Schedules<Test>>::get(42).is_some());
         assert_eq!(System::events().len(), 2);
         System::assert_has_event(mock::RuntimeEvent::Vesting(Event::VestingUpdated {
@@ -430,8 +430,8 @@ fn update_vesting_works_full_unlock() {
 
         // Check test preconditions.
         assert!(<Schedules<Test>>::get(42).is_some());
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -453,8 +453,8 @@ fn update_vesting_works_full_unlock() {
         ));
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
         assert!(<Schedules<Test>>::get(42).is_none());
         assert_eq!(System::events().len(), 2);
         System::assert_has_event(mock::RuntimeEvent::Vesting(Event::VestingUpdated {
@@ -482,8 +482,8 @@ fn update_vesting_no_vesting_error() {
 
         // Check test preconditions.
         assert!(<Schedules<Test>>::get(42).is_none());
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -500,8 +500,8 @@ fn update_vesting_no_vesting_error() {
         );
 
         // Assert state changes.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
         assert!(<Schedules<Test>>::get(42).is_none());
         assert_eq!(System::events().len(), 0);
 
@@ -546,8 +546,8 @@ fn evaluate_lock_works_full() {
         <Schedules<Test>>::insert(42, MockSchedule);
 
         // Check test preconditions.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -582,8 +582,8 @@ fn evaluate_lock_works_partial() {
         <Schedules<Test>>::insert(42, MockSchedule);
 
         // Check test preconditions.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -616,8 +616,8 @@ fn evaluate_lock_no_vesting_error() {
         Balances::make_free_balance_be(&42, 1000);
 
         // Check test preconditions.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 1000);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 1000);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =
@@ -645,8 +645,8 @@ fn evaluate_lock_computation_failure() {
         <Schedules<Test>>::insert(42, MockSchedule);
 
         // Check test preconditions.
-        assert_eq!(Balances::free_balance(&42), 1000);
-        assert_eq!(Balances::usable_balance(&42), 900);
+        assert_eq!(Balances::free_balance(42), 1000);
+        assert_eq!(Balances::usable_balance(42), 900);
 
         // Set mock expectations.
         let compute_balance_under_lock_ctx =

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-08-25"
+channel = "nightly-2023-03-04"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-01-11"
+channel = "nightly-2023-09-04"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "nightly-2023-09-04"
+channel = "nightly-2023-08-25"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]
 profile = "minimal"

--- a/utils/checks/snapshots/features.yaml
+++ b/utils/checks/snapshots/features.yaml
@@ -2276,7 +2276,7 @@
     - syn-error
 - name: proc-macro-error-attr 1.0.4
   features: []
-- name: proc-macro2 1.0.56
+- name: proc-macro2 1.0.66
   features:
     - default
     - proc-macro


### PR DESCRIPTION
Had this odd error locally, figured something is off with the Rust lang distribution system for the old nightlies. So we are updating to a new, not yet obsolete, nightly!

---

UPD: the upgrade actually causes another error:

```shell
2023-09-07 05:08:41 Running in --dev mode, RPC CORS has been disabled.
2023-09-07 05:08:41 Humanode Node
2023-09-07 05:08:41 ✌️  version 4d6c563c2a7ce73d08da72e61997f146179076ce
2023-09-07 05:08:41 ❤️  by Humanode Core, 2021-2023
2023-09-07 05:08:41 📋 Chain specification: Development
2023-09-07 05:08:41 🏷  Node name: giddy-kite-8891
2023-09-07 05:08:41 👤 Role: AUTHORITY
2023-09-07 05:08:41 💾 Database: RocksDb at /var/folders/cn/860vwq3j5zv_7_vzbtdfq9h40000gn/T/substratexpBMbr/chains/dev/db/full
2023-09-07 05:08:41 ⛓  Native runtime: humanode-108 (humanode-1.tx1.au1)
2023-09-07 05:08:41    Build info - commit sha: 4d6c563c2a7ce73d08da72e61997f146179076ce
2023-09-07 05:08:41    Build info - cargo debug profile: true
2023-09-07 05:08:41    Build info - cargo features: default
Error: Service(Client(VersionInvalid("cannot deserialize module: UnknownOpcode(192)")))
2023-09-07 05:08:42 Cannot create a runtime error=Other("cannot deserialize module: UnknownOpcode(192)")
```

This is a known issue and is fixed in the latest substrate - but it is not fixed in our fork just yet. So I applied a downgrade.