### PR TITLE
Enable binary search gas estimate feature for the RPC

### DIFF
--- a/crates/humanode-rpc/Cargo.toml
+++ b/crates/humanode-rpc/Cargo.toml
@@ -14,7 +14,7 @@ humanode-runtime = { path = "../humanode-runtime" }
 robonode-client = { path = "../robonode-client" }
 
 fc-db = { workspace = true }
-fc-rpc = { workspace = true }
+fc-rpc = { workspace = true, features = ["rpc-binary-search-estimate"] }
 fc-rpc-core = { workspace = true }
 fc-storage = { workspace = true }
 fp-rpc = { workspace = true }

--- a/utils/checks/snapshots/features.yaml
+++ b/utils/checks/snapshots/features.yaml
@@ -867,7 +867,8 @@
 - name: fc-mapping-sync 2.0.0-dev
   features: []
 - name: fc-rpc 2.0.0-dev
-  features: []
+  features:
+    - rpc-binary-search-estimate
 - name: fc-rpc-core 1.1.0-dev
   features: []
 - name: fc-storage 1.0.0-dev


### PR DESCRIPTION
This fixes issues with gas estimates. It uses an ugly hack that frontier employs to solve the issue that really comes, it seems, right from the SputnikVM.


What happens is the SputnikVM runs first, which sometimes produces a gas value that is a huge overestimate. Then the a series of non-estimate runs are executed with a binary search supplying different max gas values ranging from the lowest (21000) to the overestimate that SputnikVM provided - such that the lowest accepted value is returned. The downside of this is that the contract runs multiple times (can be a lot of times really, although there are a few tweaks to avoid too small steps and etc - https://github.com/paritytech/frontier/blob/aff019dab06120d804d3000fb8ee3d7ba920e272/client/rpc/src/eth/execute.rs#L424).

Good points: it works.
Bad points: it is a gross hack that works, so there is no motivation for anyone to do a proper fix.

It seems, just like everyone else, we have to take it, and move on.