### PR TITLE
Bump warp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5173,6 +5173,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
+
+[[package]]
 name = "multiaddr"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5269,20 +5287,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "multiparty"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed1ec6589a6d4a1e0b33b4c0a3f6ee96dfba88ebdb3da51403fd7cf0a24a4b04"
-dependencies = [
- "bytes",
- "futures-core",
- "httparse",
- "memchr",
- "pin-project-lite 0.2.9",
- "try-lock",
-]
 
 [[package]]
 name = "multistream-select"
@@ -7484,7 +7488,7 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
+ "spin 0.5.2",
  "untrusted",
  "web-sys",
  "winapi",
@@ -9980,6 +9984,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "spki"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10509,9 +10519,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
+checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
 dependencies = [
  "futures-util",
  "log",
@@ -10836,13 +10846,13 @@ checksum = "f4f195fd851901624eee5a58c4bb2b4f06399148fcd0ed336e6f1cb60a9881df"
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
+checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
- "base64 0.13.1",
  "byteorder",
  "bytes",
+ "data-encoding",
  "http",
  "httparse",
  "log",
@@ -10880,7 +10890,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.6",
- "rand 0.8.5",
+ "rand 0.7.3",
  "static_assertions",
 ]
 
@@ -11124,9 +11134,9 @@ dependencies = [
 
 [[package]]
 name = "warp"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27e1a710288f0f91a98dd8a74f05b76a10768db245ce183edf64dc1afdc3016c"
+checksum = "c1e92e22e03ff1230c03a1a8ee37d2f89cd489e2e541b7550d6afad96faed169"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -11137,7 +11147,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "multiparty",
+ "multer",
  "percent-encoding",
  "pin-project",
  "rustls-pemfile",

--- a/utils/checks/snapshots/features.yaml
+++ b/utils/checks/snapshots/features.yaml
@@ -1627,6 +1627,9 @@
   features: []
 - name: mockall_derive 0.11.4
   features: []
+- name: multer 2.1.0
+  features:
+    - default
 - name: multiaddr 0.16.0
   features:
     - default
@@ -1675,15 +1678,6 @@
     - std
 - name: multimap 0.8.3
   features: []
-- name: multiparty 0.1.0
-  features:
-    - futures-core
-    - futures03
-    - httparse
-    - memchr
-    - pin-project-lite
-    - server
-    - try-lock
 - name: multistream-select 0.12.1
   features: []
 - name: nalgebra 0.27.1
@@ -3165,6 +3159,10 @@
     - std
 - name: spin 0.5.2
   features: []
+- name: spin 0.9.8
+  features:
+    - mutex
+    - spin_mutex
 - name: spki 0.6.0
   features:
     - alloc
@@ -3360,7 +3358,7 @@
     - sync
     - time
     - tokio-util
-- name: tokio-tungstenite 0.18.0
+- name: tokio-tungstenite 0.20.1
   features:
     - connect
     - default
@@ -3490,9 +3488,9 @@
   features: []
 - name: tt-call 1.0.9
   features: []
-- name: tungstenite 0.18.0
+- name: tungstenite 0.20.1
   features:
-    - base64
+    - data-encoding
     - handshake
     - http
     - httparse
@@ -3602,11 +3600,11 @@
   features: []
 - name: want 0.3.0
   features: []
-- name: warp 0.3.4
+- name: warp 0.3.6
   features:
     - default
+    - multer
     - multipart
-    - multiparty
     - tokio-tungstenite
     - websocket
 - name: wasi 0.10.0+wasi-snapshot-preview1


### PR DESCRIPTION
This update addresses https://rustsec.org/advisories/RUSTSEC-2023-0065.