### PR TITLE
Integrate all eips related available frontier precompiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,6 +280,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
+name = "ark-bls12-377"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
+dependencies = [
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
+]
+
+[[package]]
 name = "ark-bls12-381"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4127,6 +4138,7 @@ dependencies = [
  "pallet-evm-accounts-mapping",
  "pallet-evm-balances",
  "pallet-evm-precompile-blake2",
+ "pallet-evm-precompile-bls12377",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
@@ -6512,6 +6524,18 @@ name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
 source = "git+https://github.com/humanode-network/frontier?branch=locked/polkadot-v0.9.40#ac5c3415f47adf126419579924052daff07301e1"
 dependencies = [
+ "fp-evm",
+]
+
+[[package]]
+name = "pallet-evm-precompile-bls12377"
+version = "1.0.0-dev"
+source = "git+https://github.com/humanode-network/frontier?branch=locked/polkadot-v0.9.40#ac5c3415f47adf126419579924052daff07301e1"
+dependencies = [
+ "ark-bls12-377",
+ "ark-ec",
+ "ark-ff",
+ "ark-std",
  "fp-evm",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4126,6 +4126,7 @@ dependencies = [
  "pallet-evm",
  "pallet-evm-accounts-mapping",
  "pallet-evm-balances",
+ "pallet-evm-precompile-blake2",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
@@ -6504,6 +6505,14 @@ dependencies = [
  "scale-info",
  "sp-runtime",
  "sp-std",
+]
+
+[[package]]
+name = "pallet-evm-precompile-blake2"
+version = "2.0.0-dev"
+source = "git+https://github.com/humanode-network/frontier?branch=locked/polkadot-v0.9.40#ac5c3415f47adf126419579924052daff07301e1"
+dependencies = [
+ "fp-evm",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,17 +280,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bddcadddf5e9015d310179a59bb28c4d4b9920ad0f11e8e14dbadf654890c9a6"
 
 [[package]]
-name = "ark-bls12-377"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
-dependencies = [
- "ark-ec",
- "ark-ff",
- "ark-std",
-]
-
-[[package]]
 name = "ark-bls12-381"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4138,7 +4127,6 @@ dependencies = [
  "pallet-evm-accounts-mapping",
  "pallet-evm-balances",
  "pallet-evm-precompile-blake2",
- "pallet-evm-precompile-bls12377",
  "pallet-evm-precompile-bn128",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
@@ -6525,18 +6513,6 @@ name = "pallet-evm-precompile-blake2"
 version = "2.0.0-dev"
 source = "git+https://github.com/humanode-network/frontier?branch=locked/polkadot-v0.9.40#ac5c3415f47adf126419579924052daff07301e1"
 dependencies = [
- "fp-evm",
-]
-
-[[package]]
-name = "pallet-evm-precompile-bls12377"
-version = "1.0.0-dev"
-source = "git+https://github.com/humanode-network/frontier?branch=locked/polkadot-v0.9.40#ac5c3415f47adf126419579924052daff07301e1"
-dependencies = [
- "ark-bls12-377",
- "ark-ec",
- "ark-ff",
- "ark-std",
  "fp-evm",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4139,6 +4139,7 @@ dependencies = [
  "pallet-evm-balances",
  "pallet-evm-precompile-blake2",
  "pallet-evm-precompile-bls12377",
+ "pallet-evm-precompile-bn128",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
@@ -6537,6 +6538,16 @@ dependencies = [
  "ark-ff",
  "ark-std",
  "fp-evm",
+]
+
+[[package]]
+name = "pallet-evm-precompile-bn128"
+version = "2.0.0-dev"
+source = "git+https://github.com/humanode-network/frontier?branch=locked/polkadot-v0.9.40#ac5c3415f47adf126419579924052daff07301e1"
+dependencies = [
+ "fp-evm",
+ "sp-core",
+ "substrate-bn",
 ]
 
 [[package]]
@@ -11060,6 +11071,19 @@ dependencies = [
  "schnorrkel",
  "sha2 0.9.9",
  "zeroize",
+]
+
+[[package]]
+name = "substrate-bn"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b5bbfa79abbae15dd642ea8176a21a635ff3c00059961d1ea27ad04e5b441c"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "lazy_static",
+ "rand 0.8.5",
+ "rustc-hex",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,6 @@ pallet-ethereum = { git = "https://github.com/humanode-network/frontier", branch
 pallet-evm = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-balances = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-blake2 = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
-pallet-evm-precompile-bls12377 = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-bn128 = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-modexp = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-sha3fips = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ fp-storage = { git = "https://github.com/humanode-network/frontier", branch = "l
 pallet-ethereum = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-balances = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
+pallet-evm-precompile-blake2 = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-modexp = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-sha3fips = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-simple = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,6 +159,7 @@ pallet-evm = { git = "https://github.com/humanode-network/frontier", branch = "l
 pallet-evm-balances = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-blake2 = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-bls12377 = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
+pallet-evm-precompile-bn128 = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-modexp = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-sha3fips = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-simple = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ pallet-ethereum = { git = "https://github.com/humanode-network/frontier", branch
 pallet-evm = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-balances = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-blake2 = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
+pallet-evm-precompile-bls12377 = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-modexp = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-sha3fips = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }
 pallet-evm-precompile-simple = { git = "https://github.com/humanode-network/frontier", branch = "locked/polkadot-v0.9.40", default-features = false }

--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -64,6 +64,7 @@ pallet-balances = { workspace = true }
 pallet-ethereum = { workspace = true }
 pallet-evm = { workspace = true }
 pallet-evm-balances = { workspace = true }
+pallet-evm-precompile-blake2 = { workspace = true }
 pallet-evm-precompile-modexp = { workspace = true }
 pallet-evm-precompile-sha3fips = { workspace = true }
 pallet-evm-precompile-simple = { workspace = true }
@@ -173,6 +174,7 @@ std = [
   "pallet-ethereum-chain-id/std",
   "pallet-ethereum/std",
   "pallet-evm-accounts-mapping/std",
+  "pallet-evm-precompile-blake2/std",
   "pallet-evm-precompile-modexp/std",
   "pallet-evm-precompile-sha3fips/std",
   "pallet-evm-precompile-simple/std",

--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -66,6 +66,7 @@ pallet-evm = { workspace = true }
 pallet-evm-balances = { workspace = true }
 pallet-evm-precompile-blake2 = { workspace = true }
 pallet-evm-precompile-bls12377 = { workspace = true }
+pallet-evm-precompile-bn128 = { workspace = true }
 pallet-evm-precompile-modexp = { workspace = true }
 pallet-evm-precompile-sha3fips = { workspace = true }
 pallet-evm-precompile-simple = { workspace = true }
@@ -177,6 +178,7 @@ std = [
   "pallet-evm-accounts-mapping/std",
   "pallet-evm-precompile-blake2/std",
   "pallet-evm-precompile-bls12377/std",
+  "pallet-evm-precompile-bn128/std",
   "pallet-evm-precompile-modexp/std",
   "pallet-evm-precompile-sha3fips/std",
   "pallet-evm-precompile-simple/std",

--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -65,6 +65,7 @@ pallet-ethereum = { workspace = true }
 pallet-evm = { workspace = true }
 pallet-evm-balances = { workspace = true }
 pallet-evm-precompile-blake2 = { workspace = true }
+pallet-evm-precompile-bls12377 = { workspace = true }
 pallet-evm-precompile-modexp = { workspace = true }
 pallet-evm-precompile-sha3fips = { workspace = true }
 pallet-evm-precompile-simple = { workspace = true }
@@ -175,6 +176,7 @@ std = [
   "pallet-ethereum/std",
   "pallet-evm-accounts-mapping/std",
   "pallet-evm-precompile-blake2/std",
+  "pallet-evm-precompile-bls12377/std",
   "pallet-evm-precompile-modexp/std",
   "pallet-evm-precompile-sha3fips/std",
   "pallet-evm-precompile-simple/std",

--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -65,7 +65,6 @@ pallet-ethereum = { workspace = true }
 pallet-evm = { workspace = true }
 pallet-evm-balances = { workspace = true }
 pallet-evm-precompile-blake2 = { workspace = true }
-pallet-evm-precompile-bls12377 = { workspace = true }
 pallet-evm-precompile-bn128 = { workspace = true }
 pallet-evm-precompile-modexp = { workspace = true }
 pallet-evm-precompile-sha3fips = { workspace = true }
@@ -177,7 +176,6 @@ std = [
   "pallet-ethereum/std",
   "pallet-evm-accounts-mapping/std",
   "pallet-evm-precompile-blake2/std",
-  "pallet-evm-precompile-bls12377/std",
   "pallet-evm-precompile-bn128/std",
   "pallet-evm-precompile-modexp/std",
   "pallet-evm-precompile-sha3fips/std",

--- a/crates/humanode-runtime/src/frontier_precompiles.rs
+++ b/crates/humanode-runtime/src/frontier_precompiles.rs
@@ -3,6 +3,10 @@ use pallet_evm::{
     IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult, PrecompileSet,
 };
 use pallet_evm_precompile_blake2::Blake2F;
+use pallet_evm_precompile_bls12377::{
+    Bls12377G1Add, Bls12377G1Mul, Bls12377G1MultiExp, Bls12377G2Add, Bls12377G2Mul,
+    Bls12377G2MultiExp, Bls12377Pairing,
+};
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
@@ -54,6 +58,21 @@ pub mod precompiles_constants {
     /// `Bls12381MapG2` precompile constant.
     pub const BLS12381_MAP_G2: u64 = 19;
 
+    /// `Bls12377G1Add` precompile constant.
+    pub const BLS12377_G1_ADD: u64 = 21;
+    /// `Bls12377G1Mul` precompile constant.
+    pub const BLS12377_G1_MUL: u64 = 22;
+    /// `Bls12377G1MultiExp` precompile constant.
+    pub const BLS12377_G1_MULTI_EXP: u64 = 23;
+    /// `Bls12377G2Add` precompile constant.
+    pub const BLS12377_G2_ADD: u64 = 24;
+    /// `Bls12377G2Mul` precompile constant.
+    pub const BLS12377_G2_MUL: u64 = 25;
+    /// `Bls12377G2MultiExp` precompile constant.
+    pub const BLS12377_G2_MULTI_EXP: u64 = 26;
+    /// `Bls12377Pairing` precompile constant.
+    pub const BLS12377_PAIRING: u64 = 27;
+
     /// `Sha3FIPS256` precompile constant.
     pub const SHA_3_FIPS256: u64 = 1024;
     /// `ECRecoverPublicKey` precompile constant.
@@ -100,6 +119,13 @@ where
             BLS12381_PAIRING,
             BLS12381_MAP_G1,
             BLS12381_MAP_G2,
+            BLS12377_G1_ADD,
+            BLS12377_G1_MUL,
+            BLS12377_G1_MULTI_EXP,
+            BLS12377_G2_ADD,
+            BLS12377_G2_MUL,
+            BLS12377_G2_MULTI_EXP,
+            BLS12377_PAIRING,
             SHA_3_FIPS256,
             EC_RECOVER_PUBLIC_KEY,
             BIOAUTH,
@@ -146,6 +172,14 @@ where
             a if a == hash(BLS12381_PAIRING) => Some(Bls12381Pairing::execute(handle)),
             a if a == hash(BLS12381_MAP_G1) => Some(Bls12381MapG1::execute(handle)),
             a if a == hash(BLS12381_MAP_G2) => Some(Bls12381MapG2::execute(handle)),
+            // BLS12-377 precompiles:
+            a if a == hash(BLS12377_G1_ADD) => Some(Bls12377G1Add::execute(handle)),
+            a if a == hash(BLS12377_G1_MUL) => Some(Bls12377G1Mul::execute(handle)),
+            a if a == hash(BLS12377_G1_MULTI_EXP) => Some(Bls12377G1MultiExp::execute(handle)),
+            a if a == hash(BLS12377_G2_ADD) => Some(Bls12377G2Add::execute(handle)),
+            a if a == hash(BLS12377_G2_MUL) => Some(Bls12377G2Mul::execute(handle)),
+            a if a == hash(BLS12377_G2_MULTI_EXP) => Some(Bls12377G2MultiExp::execute(handle)),
+            a if a == hash(BLS12377_PAIRING) => Some(Bls12377Pairing::execute(handle)),
             // Non-Frontier specific nor Ethereum precompiles :
             a if a == hash(SHA_3_FIPS256) => Some(Sha3FIPS256::execute(handle)),
             a if a == hash(EC_RECOVER_PUBLIC_KEY) => Some(ECRecoverPublicKey::execute(handle)),

--- a/crates/humanode-runtime/src/frontier_precompiles.rs
+++ b/crates/humanode-runtime/src/frontier_precompiles.rs
@@ -2,6 +2,7 @@ use frame_support::traits::Currency;
 use pallet_evm::{
     IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult, PrecompileSet,
 };
+use pallet_evm_precompile_blake2::Blake2F;
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
@@ -31,6 +32,8 @@ pub mod precompiles_constants {
     pub const IDENTITY: u64 = 4;
     /// `Modexp` precompile constant.
     pub const MODEXP: u64 = 5;
+    /// `Blake2F` precompile constant.
+    pub const BLAKE2F: u64 = 9;
 
     /// `Bls12381G1Add` precompile constant.
     pub const BLS12381_G1_ADD: u64 = 11;
@@ -87,6 +90,7 @@ where
             RIPEMD_160,
             IDENTITY,
             MODEXP,
+            BLAKE2F,
             BLS12381_G1_ADD,
             BLS12381_G1_MUL,
             BLS12381_G1_MULTI_EXP,
@@ -131,6 +135,7 @@ where
             a if a == hash(RIPEMD_160) => Some(Ripemd160::execute(handle)),
             a if a == hash(IDENTITY) => Some(Identity::execute(handle)),
             a if a == hash(MODEXP) => Some(Modexp::execute(handle)),
+            a if a == hash(BLAKE2F) => Some(Blake2F::execute(handle)),
             // BLS12-381 precompiles:
             a if a == hash(BLS12381_G1_ADD) => Some(Bls12381G1Add::execute(handle)),
             a if a == hash(BLS12381_G1_MUL) => Some(Bls12381G1Mul::execute(handle)),

--- a/crates/humanode-runtime/src/frontier_precompiles.rs
+++ b/crates/humanode-runtime/src/frontier_precompiles.rs
@@ -7,6 +7,7 @@ use pallet_evm_precompile_bls12377::{
     Bls12377G1Add, Bls12377G1Mul, Bls12377G1MultiExp, Bls12377G2Add, Bls12377G2Mul,
     Bls12377G2MultiExp, Bls12377Pairing,
 };
+use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
@@ -36,6 +37,14 @@ pub mod precompiles_constants {
     pub const IDENTITY: u64 = 4;
     /// `Modexp` precompile constant.
     pub const MODEXP: u64 = 5;
+
+    /// `Bn128Add` precompile constant.
+    pub const BN128_ADD: u64 = 6;
+    /// `Bn128Mul` precompile constant.
+    pub const BN128_MUL: u64 = 7;
+    /// `Bn128Pairing` precompile constant.
+    pub const BN128_PAIRING: u64 = 8;
+
     /// `Blake2F` precompile constant.
     pub const BLAKE2F: u64 = 9;
 
@@ -109,6 +118,9 @@ where
             RIPEMD_160,
             IDENTITY,
             MODEXP,
+            BN128_ADD,
+            BN128_MUL,
+            BN128_PAIRING,
             BLAKE2F,
             BLS12381_G1_ADD,
             BLS12381_G1_MUL,
@@ -161,6 +173,11 @@ where
             a if a == hash(RIPEMD_160) => Some(Ripemd160::execute(handle)),
             a if a == hash(IDENTITY) => Some(Identity::execute(handle)),
             a if a == hash(MODEXP) => Some(Modexp::execute(handle)),
+            // Bn128 precompiles:
+            a if a == hash(BN128_ADD) => Some(Bn128Add::execute(handle)),
+            a if a == hash(BN128_MUL) => Some(Bn128Mul::execute(handle)),
+            a if a == hash(BN128_PAIRING) => Some(Bn128Pairing::execute(handle)),
+            // Blake-2 precompiles:
             a if a == hash(BLAKE2F) => Some(Blake2F::execute(handle)),
             // BLS12-381 precompiles:
             a if a == hash(BLS12381_G1_ADD) => Some(Bls12381G1Add::execute(handle)),

--- a/crates/humanode-runtime/src/frontier_precompiles.rs
+++ b/crates/humanode-runtime/src/frontier_precompiles.rs
@@ -3,10 +3,6 @@ use pallet_evm::{
     IsPrecompileResult, Precompile, PrecompileHandle, PrecompileResult, PrecompileSet,
 };
 use pallet_evm_precompile_blake2::Blake2F;
-use pallet_evm_precompile_bls12377::{
-    Bls12377G1Add, Bls12377G1Mul, Bls12377G1MultiExp, Bls12377G2Add, Bls12377G2Mul,
-    Bls12377G2MultiExp, Bls12377Pairing,
-};
 use pallet_evm_precompile_bn128::{Bn128Add, Bn128Mul, Bn128Pairing};
 use pallet_evm_precompile_modexp::Modexp;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
@@ -67,21 +63,6 @@ pub mod precompiles_constants {
     /// `Bls12381MapG2` precompile constant.
     pub const BLS12381_MAP_G2: u64 = 19;
 
-    /// `Bls12377G1Add` precompile constant.
-    pub const BLS12377_G1_ADD: u64 = 21;
-    /// `Bls12377G1Mul` precompile constant.
-    pub const BLS12377_G1_MUL: u64 = 22;
-    /// `Bls12377G1MultiExp` precompile constant.
-    pub const BLS12377_G1_MULTI_EXP: u64 = 23;
-    /// `Bls12377G2Add` precompile constant.
-    pub const BLS12377_G2_ADD: u64 = 24;
-    /// `Bls12377G2Mul` precompile constant.
-    pub const BLS12377_G2_MUL: u64 = 25;
-    /// `Bls12377G2MultiExp` precompile constant.
-    pub const BLS12377_G2_MULTI_EXP: u64 = 26;
-    /// `Bls12377Pairing` precompile constant.
-    pub const BLS12377_PAIRING: u64 = 27;
-
     /// `Sha3FIPS256` precompile constant.
     pub const SHA_3_FIPS256: u64 = 1024;
     /// `ECRecoverPublicKey` precompile constant.
@@ -131,13 +112,6 @@ where
             BLS12381_PAIRING,
             BLS12381_MAP_G1,
             BLS12381_MAP_G2,
-            BLS12377_G1_ADD,
-            BLS12377_G1_MUL,
-            BLS12377_G1_MULTI_EXP,
-            BLS12377_G2_ADD,
-            BLS12377_G2_MUL,
-            BLS12377_G2_MULTI_EXP,
-            BLS12377_PAIRING,
             SHA_3_FIPS256,
             EC_RECOVER_PUBLIC_KEY,
             BIOAUTH,
@@ -189,14 +163,6 @@ where
             a if a == hash(BLS12381_PAIRING) => Some(Bls12381Pairing::execute(handle)),
             a if a == hash(BLS12381_MAP_G1) => Some(Bls12381MapG1::execute(handle)),
             a if a == hash(BLS12381_MAP_G2) => Some(Bls12381MapG2::execute(handle)),
-            // BLS12-377 precompiles:
-            a if a == hash(BLS12377_G1_ADD) => Some(Bls12377G1Add::execute(handle)),
-            a if a == hash(BLS12377_G1_MUL) => Some(Bls12377G1Mul::execute(handle)),
-            a if a == hash(BLS12377_G1_MULTI_EXP) => Some(Bls12377G1MultiExp::execute(handle)),
-            a if a == hash(BLS12377_G2_ADD) => Some(Bls12377G2Add::execute(handle)),
-            a if a == hash(BLS12377_G2_MUL) => Some(Bls12377G2Mul::execute(handle)),
-            a if a == hash(BLS12377_G2_MULTI_EXP) => Some(Bls12377G2MultiExp::execute(handle)),
-            a if a == hash(BLS12377_PAIRING) => Some(Bls12377Pairing::execute(handle)),
             // Non-Frontier specific nor Ethereum precompiles :
             a if a == hash(SHA_3_FIPS256) => Some(Sha3FIPS256::execute(handle)),
             a if a == hash(EC_RECOVER_PUBLIC_KEY) => Some(ECRecoverPublicKey::execute(handle)),

--- a/utils/checks/snapshots/features.yaml
+++ b/utils/checks/snapshots/features.yaml
@@ -2196,6 +2196,12 @@
   features:
     - default
     - std
+- name: pallet-evm-precompile-blake2 2.0.0-dev
+  features:
+    - std
+- name: pallet-evm-precompile-bn128 2.0.0-dev
+  features:
+    - std
 - name: pallet-evm-precompile-modexp 2.0.0-dev
   features:
     - std
@@ -3541,6 +3547,8 @@
   features:
     - default
 - name: substrate-bip39 0.4.5
+  features: []
+- name: substrate-bn 0.6.0
   features: []
 - name: substrate-frame-rpc-system 4.0.0-dev
   features: []


### PR DESCRIPTION
## All precompiles

https://github.com/humanode-network/frontier/tree/locked/polkadot-v0.9.40/frame/evm/precompile

## Result

### Blake-2 (added)

- https://eips.ethereum.org/EIPS/eip-152

### Bls12377 (not added, draft)

- https://eips.ethereum.org/EIPS/eip-2539

### Bn128 (added)

- https://eips.ethereum.org/EIPS/eip-196
- https://eips.ethereum.org/EIPS/eip-197
- https://eips.ethereum.org/EIPS/eip-1108

### bw6761 (not added, stagnant)

- https://eips.ethereum.org/EIPS/eip-3026

### curve25519 (not added, eip doesn't exist)

### ed25519 (not added, stagnant)

- https://eips.ethereum.org/EIPS/eip-665

### dispatch (not added, substrate related logic, eip doesn't exist)

### sha3fips (not added, eip doesn't exist)