### PR TITLE
Fix unused manifest keys at cargo

### DIFF
--- a/crates/author-ext-api/Cargo.toml
+++ b/crates/author-ext-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec" }
+codec = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 sp-api = { workspace = true }
 sp-std = { workspace = true }

--- a/crates/bioauth-flow-api/Cargo.toml
+++ b/crates/bioauth-flow-api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec" }
+codec = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 sp-api = { workspace = true }
 sp-std = { workspace = true }

--- a/crates/humanode-peer/Cargo.toml
+++ b/crates/humanode-peer/Cargo.toml
@@ -24,7 +24,7 @@ robonode-client = { path = "../robonode-client" }
 
 async-trait = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-codec = { workspace = true, package = "parity-scale-codec" }
+codec = { workspace = true }
 fc-cli = { workspace = true }
 fc-consensus = { workspace = true }
 fc-db = { workspace = true, features = ["sql"] }

--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -45,7 +45,7 @@ vesting-schedule-linear = { path = "../vesting-schedule-linear", default-feature
 vesting-scheduling-timestamp = { path = "../vesting-scheduling-timestamp", default-features = false }
 
 chrono = { workspace = true }
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 fp-evm = { workspace = true }
 fp-rpc = { workspace = true }
 fp-self-contained = { workspace = true }

--- a/crates/keystore-bioauth-account-id/Cargo.toml
+++ b/crates/keystore-bioauth-account-id/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 sp-application-crypto = { workspace = true }

--- a/crates/pallet-balanced-currency-swap-bridges-initializer/Cargo.toml
+++ b/crates/pallet-balanced-currency-swap-bridges-initializer/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }

--- a/crates/pallet-bioauth/Cargo.toml
+++ b/crates/pallet-bioauth/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }

--- a/crates/pallet-bootnodes/Cargo.toml
+++ b/crates/pallet-bootnodes/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }

--- a/crates/pallet-chain-properties/Cargo.toml
+++ b/crates/pallet-chain-properties/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }

--- a/crates/pallet-chain-start-moment/Cargo.toml
+++ b/crates/pallet-chain-start-moment/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }

--- a/crates/pallet-currency-swap/Cargo.toml
+++ b/crates/pallet-currency-swap/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 primitives-currency-swap = { path = "../primitives-currency-swap", default-features = false }
 
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }

--- a/crates/pallet-dummy-precompiles-code/Cargo.toml
+++ b/crates/pallet-dummy-precompiles-code/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-evm = { workspace = true }

--- a/crates/pallet-erc20-support/Cargo.toml
+++ b/crates/pallet-erc20-support/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }

--- a/crates/pallet-ethereum-chain-id/Cargo.toml
+++ b/crates/pallet-ethereum-chain-id/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }

--- a/crates/pallet-evm-accounts-mapping/Cargo.toml
+++ b/crates/pallet-evm-accounts-mapping/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 primitives-ethereum = { path = "../primitives-ethereum", default-features = false }
 
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }

--- a/crates/pallet-humanode-session/Cargo.toml
+++ b/crates/pallet-humanode-session/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 pallet-bioauth = { path = "../pallet-bioauth", default-features = false }
 pallet-bootnodes = { path = "../pallet-bootnodes", default-features = false }
 
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-session = { workspace = true, features = ["historical"] }

--- a/crates/pallet-pot/Cargo.toml
+++ b/crates/pallet-pot/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }

--- a/crates/pallet-token-claims/Cargo.toml
+++ b/crates/pallet-token-claims/Cargo.toml
@@ -10,7 +10,7 @@ ignored = ["serde"]
 [dependencies]
 primitives-ethereum = { path = "../primitives-ethereum", default-features = false }
 
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }

--- a/crates/pallet-vesting/Cargo.toml
+++ b/crates/pallet-vesting/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 ignored = ["serde"]
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-benchmarking = { workspace = true, optional = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }

--- a/crates/precompile-bioauth/Cargo.toml
+++ b/crates/precompile-bioauth/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 pallet-bioauth = { path = "../pallet-bioauth", default-features = false }
 precompile-utils = { path = "../precompile-utils", default-features = false }
 
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 fp-evm = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }

--- a/crates/precompile-currency-swap/Cargo.toml
+++ b/crates/precompile-currency-swap/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 precompile-utils = { path = "../precompile-utils", default-features = false }
 primitives-currency-swap = { path = "../primitives-currency-swap", default-features = false }
 
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 fp-evm = { workspace = true }
 frame-support = { workspace = true }
 num_enum = { workspace = true }

--- a/crates/precompile-evm-accounts-mapping/Cargo.toml
+++ b/crates/precompile-evm-accounts-mapping/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 pallet-evm-accounts-mapping = { path = "../pallet-evm-accounts-mapping", default-features = false }
 primitives-ethereum = { path = "../primitives-ethereum", default-features = false }
 
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 fp-evm = { workspace = true }
 sp-std = { workspace = true }
 

--- a/crates/precompile-native-currency/Cargo.toml
+++ b/crates/precompile-native-currency/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 pallet-erc20-support = { path = "../pallet-erc20-support", default-features = false }
 precompile-utils = { path = "../precompile-utils", default-features = false }
 
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 fp-evm = { workspace = true }
 frame-support = { workspace = true }
 num_enum = { workspace = true }

--- a/crates/precompile-utils/Cargo.toml
+++ b/crates/precompile-utils/Cargo.toml
@@ -16,7 +16,7 @@ similar-asserts = { workspace = true, optional = true, features = ["default"] }
 precompile-utils-macro = { path = "macro" }
 
 # Substrate
-codec = { workspace = true, package = "parity-scale-codec" }
+codec = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 sp-core = { workspace = true }

--- a/crates/primitives-auth-ticket/Cargo.toml
+++ b/crates/primitives-auth-ticket/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"], optional = true }
 sp-std = { workspace = true }

--- a/crates/primitives-ethereum/Cargo.toml
+++ b/crates/primitives-ethereum/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 frame-support = { workspace = true }
 rustc-hex = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }

--- a/crates/primitives-liveness-data/Cargo.toml
+++ b/crates/primitives-liveness-data/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive"] }
+codec = { workspace = true, features = ["derive"] }
 scale-info = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 

--- a/crates/robonode-server/Cargo.toml
+++ b/crates/robonode-server/Cargo.toml
@@ -22,7 +22,7 @@ uuid = { workspace = true, features = ["v4"] }
 warp = { workspace = true, features = ["default"] }
 
 [dev-dependencies]
-codec = { workspace = true, package = "parity-scale-codec" }
+codec = { workspace = true }
 mockall = { workspace = true }
 serde_json = { workspace = true }
 tracing-test = { workspace = true }

--- a/crates/vesting-schedule-linear/Cargo.toml
+++ b/crates/vesting-schedule-linear/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-codec = { workspace = true, package = "parity-scale-codec", features = ["derive", "max-encoded-len"] }
+codec = { workspace = true, features = ["derive", "max-encoded-len"] }
 num-traits = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"], optional = true }


### PR DESCRIPTION
Closes #765 

```
➜  humanode git:(master) ✗ cargo check
   Compiling humanode-runtime v0.1.0 (/Users/dmitrylavrenov/humanode/humanode/crates/humanode-runtime)
    Checking humanode-rpc v0.1.0 (/Users/dmitrylavrenov/humanode/humanode/crates/humanode-rpc)
    Checking humanode-peer v0.1.0 (/Users/dmitrylavrenov/humanode/humanode/crates/humanode-peer)
    Finished dev [unoptimized + debuginfo] target(s) in 7.37s
```