### PR TITLE
Ignore substrate and frontier related deps by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,16 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      # Substrate and frontier related deps as all of them are controlled in our forks.
+      - dependency-name: "frame-*"
+      - dependency-name: "pallet-*"
+      - dependency-name: "sc-*"
+      - dependency-name: "sp-*"
+      - dependency-name: "fc-*"
+      - dependency-name: "fp-*"
+      - dependency-name: "substrate-*"
+      - dependency-name: "try-runtime-cli"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
I suggest to use this way of ignoring deps related to our substrate and frontier forks for now as ignoring by source isn't supported yet.

