### PR TITLE
Properly manage default on chain storage version for pallets added after genesis

### DIFF
--- a/crates/pallet-balanced-currency-swap-bridges-initializer/src/upgrade_init.rs
+++ b/crates/pallet-balanced-currency-swap-bridges-initializer/src/upgrade_init.rs
@@ -40,7 +40,7 @@ pub fn on_runtime_upgrade<T: Config>() -> Weight {
 
     weight.saturating_accrue(T::DbWeight::get().reads(1));
 
-    if onchain_storage_version == 0 && current_storage_version > 0 {
+    if onchain_storage_version == 0 && current_storage_version != 0 {
         // Set new storage version.
         current_storage_version.put::<Pallet<T>>();
 

--- a/crates/pallet-balanced-currency-swap-bridges-initializer/src/upgrade_init.rs
+++ b/crates/pallet-balanced-currency-swap-bridges-initializer/src/upgrade_init.rs
@@ -31,6 +31,23 @@ pub fn on_runtime_upgrade<T: Config>() -> Weight {
         weight.saturating_accrue(T::DbWeight::get().writes(2));
     }
 
+    // Properly manage default on chain storage version as the pallet was added after genesis
+    // with initial storage version != 0.
+    //
+    // <https://github.com/paritytech/substrate/pull/14641>
+    let current_storage_version = <Pallet<T>>::current_storage_version();
+    let onchain_storage_version = <Pallet<T>>::on_chain_storage_version();
+
+    weight.saturating_accrue(T::DbWeight::get().reads(1));
+
+    if onchain_storage_version == 0 && current_storage_version > 0 {
+        // Set new storage version.
+        current_storage_version.put::<Pallet<T>>();
+
+        // Write the onchain storage version.
+        weight = weight.saturating_add(T::DbWeight::get().writes(1));
+    }
+
     weight
 }
 
@@ -57,6 +74,11 @@ pub fn post_upgrade<T: Config>(_state: Vec<u8>) -> Result<(), &'static str> {
     }
 
     assert_eq!(storage_root_before, storage_root(StateVersion::V1));
+
+    assert_eq!(
+        <Pallet<T>>::on_chain_storage_version(),
+        <Pallet<T>>::current_storage_version()
+    );
 
     Ok(())
 }

--- a/crates/pallet-dummy-precompiles-code/src/lib.rs
+++ b/crates/pallet-dummy-precompiles-code/src/lib.rs
@@ -106,7 +106,7 @@ pub mod pallet {
 
             weight.saturating_accrue(T::DbWeight::get().reads(1));
 
-            if onchain_storage_version == 0 && current_storage_version > 0 {
+            if onchain_storage_version == 0 && current_storage_version != 0 {
                 // Set new storage version.
                 current_storage_version.put::<Pallet<T>>();
 

--- a/crates/pallet-dummy-precompiles-code/src/lib.rs
+++ b/crates/pallet-dummy-precompiles-code/src/lib.rs
@@ -97,6 +97,23 @@ pub mod pallet {
                 weight.saturating_accrue(T::DbWeight::get().writes(2));
             }
 
+            // Properly manage default on chain storage version as the pallet was added after genesis
+            // with initial storage version != 0.
+            //
+            // <https://github.com/paritytech/substrate/pull/14641>
+            let current_storage_version = <Pallet<T>>::current_storage_version();
+            let onchain_storage_version = <Pallet<T>>::on_chain_storage_version();
+
+            weight.saturating_accrue(T::DbWeight::get().reads(1));
+
+            if onchain_storage_version == 0 && current_storage_version > 0 {
+                // Set new storage version.
+                current_storage_version.put::<Pallet<T>>();
+
+                // Write the onchain storage version.
+                weight = weight.saturating_add(T::DbWeight::get().writes(1));
+            }
+
             weight
         }
 
@@ -122,6 +139,11 @@ pub mod pallet {
             if !not_created_precompiles.is_empty() {
                 return Err("precompiles not created properly: {:not_created_precompiles}");
             }
+
+            assert_eq!(
+                <Pallet<T>>::on_chain_storage_version(),
+                <Pallet<T>>::current_storage_version()
+            );
 
             Ok(())
         }


### PR DESCRIPTION
During `humanode-network` development there are some pallets that were added after genesis to our runtime containing initial `StorageVersion = 1`:
- `pallet-balanced-currency-swap-bridges-initializer` - https://github.com/humanode-network/humanode/pull/716
- `pallet-dummy-precompiles-code` - https://github.com/humanode-network/humanode/pull/777

During work on https://github.com/humanode-network/humanode/pull/940 the following changes have been acknowledged in substrate codebase - https://github.com/paritytech/substrate/commit/9957da3cbb027f9b754c453a4d58a62665e532ef. So, the following errors have been faced during `try-runtime` checks:
```
2024-10-22 18:38:43.021  INFO main runtime::frame-support: ⚠️ BalancedCurrencySwapBridgesInitializer declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `StorageVersion(1)`    
2024-10-22 18:38:43.021 ERROR main runtime::frame-support: BalancedCurrencySwapBridgesInitializer: On chain storage version StorageVersion(0) doesn't match current storage version StorageVersion(1).    
2024-10-22 18:38:43.021  INFO main runtime::frame-support: ⚠️ EvmBalancesErc20Support declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`    
2024-10-22 18:38:43.021  INFO main runtime::frame-support: ⚠️ DummyPrecompilesCode declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `StorageVersion(1)`    
2024-10-22 18:38:43.021 ERROR main runtime::frame-support: DummyPrecompilesCode: On chain storage version StorageVersion(0) doesn't match current storage version StorageVersion(1).
```

The root cause has been discovered - https://github.com/paritytech/substrate/pull/14641. Unfortunately, we should manually fix current storage versions in next runtime update.