### PR TITLE
Add `with-tracing` feature at `humanode-runtime` and enable it for `try-runtime` execution

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -35,4 +35,5 @@ rustflags = [
   "-Aclippy::cargo-common-metadata",
   "-Aclippy::derive-partial-eq-without-eq",
   "-Aclippy::multiple-crate-versions",
+  "-Aclippy::redundant-feature-names",
 ]

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -78,7 +78,7 @@ jobs:
           - suite: "base"
             build-args: ""
           - suite: "try-runtime"
-            build-args: "--features try-runtime,with-tracing"
+            build-args: "--features try-runtime"
       fail-fast: false
     name: End-to-end tests / ${{ matrix.test.suite }}
     runs-on: ubuntu-22.04

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -78,7 +78,7 @@ jobs:
           - suite: "base"
             build-args: ""
           - suite: "try-runtime"
-            build-args: "--features try-runtime"
+            build-args: "--features try-runtime,with-tracing"
       fail-fast: false
     name: End-to-end tests / ${{ matrix.test.suite }}
     runs-on: ubuntu-22.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4167,7 +4167,6 @@ dependencies = [
  "sp-session",
  "sp-staking",
  "sp-std",
- "sp-tracing",
  "sp-transaction-pool",
  "sp-version",
  "static_assertions",

--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -94,7 +94,6 @@ sp-runtime = { workspace = true }
 sp-session = { workspace = true }
 sp-staking = { workspace = true }
 sp-std = { workspace = true }
-sp-tracing = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-version = { workspace = true }
 static_assertions = { workspace = true }
@@ -224,7 +223,6 @@ std = [
   "sp-session/std",
   "sp-staking/std",
   "sp-std/std",
-  "sp-tracing/std",
   "sp-transaction-pool/std",
   "sp-version/std",
   "substrate-wasm-builder",
@@ -274,5 +272,4 @@ try-runtime = [
 with-tracing = [
   "frame-executive/with-tracing",
   "sp-io/with-tracing",
-  "sp-tracing/with-tracing"
 ]

--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -88,6 +88,7 @@ sp-block-builder = { workspace = true }
 sp-consensus-babe = { workspace = true }
 sp-core = { workspace = true }
 sp-inherents = { workspace = true }
+sp-io = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
@@ -106,7 +107,6 @@ ethereum = { workspace = true, features = ["default"] }
 hex = { workspace = true }
 hex-literal = { workspace = true }
 serde_json = { workspace = true }
-sp-io = { workspace = true }
 sp-keystore = { workspace = true }
 
 [features]
@@ -270,4 +270,9 @@ try-runtime = [
   "pallet-vesting/try-runtime",
   "primitives-currency-swap-proxy/try-runtime",
   "sp-runtime/try-runtime",
+]
+with-tracing = [
+  "frame-executive/with-tracing",
+  "sp-io/with-tracing",
+  "sp-tracing/with-tracing"
 ]

--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -1584,6 +1584,8 @@ impl_runtime_apis! {
     #[cfg(feature = "try-runtime")]
     impl frame_try_runtime::TryRuntime<Block> for Runtime {
         fn on_runtime_upgrade(checks: frame_try_runtime::UpgradeCheckSelect) -> (Weight, Weight) {
+            sp_io::init_tracing();
+
             // NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
             // have a backtrace here. If any of the pre/post migration checks fail, we shall stop
             // right here and right now.
@@ -1597,6 +1599,8 @@ impl_runtime_apis! {
             signature_check: bool,
             select: frame_try_runtime::TryStateSelect
         ) -> Weight {
+            sp_io::init_tracing();
+
             // NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
             // have a backtrace here.
             Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()

--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -1597,14 +1597,6 @@ impl_runtime_apis! {
             signature_check: bool,
             select: frame_try_runtime::TryStateSelect
         ) -> Weight {
-            sp_tracing::info!(
-                target: "humanode-runtime",
-                "try-runtime: executing block {:?} / root checks: {:?} / signature check: {:?} / try-state-select: {:?}",
-                block.header.hash(),
-                state_root_check,
-                signature_check,
-                select,
-            );
             // NOTE: intentional unwrap: we don't want to propagate the error backwards, and want to
             // have a backtrace here.
             Executive::try_execute_block(block, state_root_check, signature_check, select).unwrap()


### PR DESCRIPTION
Analysed substrate repo for tracing support. `with-tracing` feature is defined and used at:
- `frame-executive`
- `sp-io`
- `sp-tracing`

Also, found the following guide - https://github.com/humanode-network/substrate/blob/033d4e86cc7eff0066cd376b9375f815761d653c/client/rpc-api/src/state/mod.rs#L157

Tracing support is added in the same way as `frame-executive` has - https://github.com/humanode-network/substrate/blob/033d4e86cc7eff0066cd376b9375f815761d653c/frame/executive/src/lib.rs#L417.