### PR TITLE
Enable FaceTec integration tests unconditional compilation; ignore them in test runtime

### DIFF
--- a/crates/robonode-server/Cargo.toml
+++ b/crates/robonode-server/Cargo.toml
@@ -26,6 +26,3 @@ codec = { workspace = true }
 mockall = { workspace = true }
 serde_json = { workspace = true }
 tracing-test = { workspace = true }
-
-[features]
-logic-integration-tests = []

--- a/crates/robonode-server/src/logic/tests.rs
+++ b/crates/robonode-server/src/logic/tests.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "logic-integration-tests")]
-
 use std::marker::PhantomData;
 
 use facetec_api_client as ft;
@@ -174,6 +172,7 @@ async fn setup() -> (
 }
 
 #[tokio::test]
+#[ignore = "requires FaceTec server"]
 #[tracing_test::traced_test]
 async fn standalone_enroll() {
     let (_guard, test_params, logic) = setup().await;
@@ -189,6 +188,7 @@ async fn standalone_enroll() {
 }
 
 #[tokio::test]
+#[ignore = "requires FaceTec server"]
 #[tracing_test::traced_test]
 async fn first_authenticate() {
     let (_guard, test_params, logic) = setup().await;
@@ -208,6 +208,7 @@ async fn first_authenticate() {
 }
 
 #[tokio::test]
+#[ignore = "requires FaceTec server"]
 #[tracing_test::traced_test]
 async fn enroll_authenticate() {
     let (_guard, test_params, logic) = setup().await;
@@ -233,6 +234,7 @@ async fn enroll_authenticate() {
 }
 
 #[tokio::test]
+#[ignore = "requires FaceTec server"]
 #[tracing_test::traced_test]
 async fn double_enroll() {
     let (_guard, test_params, logic) = setup().await;


### PR DESCRIPTION
We want to ensure that the test build was checked in CI until there was a major reconstruction of bioauth flow and robonode.

```sh
$ cargo test
...
test logic::tests::double_enroll ... ignored, requires Facetec server
test http::tests::get_facetec_device_sdk_params_in_dev_mode ... ok
test logic::tests::enroll_authenticate ... ignored, requires Facetec server
test http::tests::enroll_error_person_already_enrolled ... ok
test logic::tests::first_authenticate ... ignored, requires Facetec server
test logic::tests::standalone_enroll ... ignored, requires Facetec server
...
$ # Doesn't require rebuild:
$ cargo test -- --include-ignored
...
test logic::tests::enroll_authenticate ... FAILED
test logic::tests::double_enroll ... FAILED
test logic::tests::first_authenticate ... FAILED
test logic::tests::standalone_enroll ... FAILED
...
```

✓ Made sure that high-level compilation errors in tests are checked (for example, type errors).

Considered other options to ignore tests after enabling their unconditional compilation:
- Controlling ignoring tests via env var — more granular than `#[ignore]`, but not in general use. Requires to add exit logic to each test. To avoid it, one could use a declarative macro, but I think there would be little benefit from it and macros should be used only as a last resort.
- Test harness Nextest, along with the `#[ignore]` attribute, [offers to set a "default filter"](https://nexte.st/docs/running/#running-a-subset-of-tests-by-default). For us, using Nextest would be an overkill for now. Nextest requires using a custom CLI testing command, which we'd like to avoid for now.

Closes: #223 