### PR TITLE
Temporarily ignore `RUSTSEC-2024-0402`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,8 @@ ignore = [
   "RUSTSEC-2024-0336",
   # TODO(#1197): update the sqlx internal dependency to 0.8.1+
   "RUSTSEC-2024-0363",
+  # TODO(#1352): update the hashbrown internal dependency to 0.15.1+
+  "RUSTSEC-2024-0402",
 ]
 
 [licenses]


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2024-0402.html

We have internal dependencies that depends on vulnerable hashbrown version. I guess, it shouldn't affect our code, so, we can ignore it for now.