### PR TITLE
Temporarily ignore RUSTSEC-2024-0421

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,8 @@ ignore = [
   "RUSTSEC-2024-0363",
   # TODO(#1352): update the hashbrown internal dependency to 0.15.1+
   "RUSTSEC-2024-0402",
+  # TODO(#1361): update the idna internal dependency to 1.0.0+
+  "RUSTSEC-2024-0421",
 ]
 
 [licenses]


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2024-0421

We have internal dependencies (libp2p) that depends on vulnerable idna version.

Based on the vulnerability description looks like we can ignore it for now.