### PR TITLE
Refactor the CheckBioauthTx

### DIFF
--- a/crates/pallet-bioauth/src/tests.rs
+++ b/crates/pallet-bioauth/src/tests.rs
@@ -4,8 +4,8 @@
 use std::ops::Div;
 
 use frame_support::{
-    assert_err, assert_noop, assert_ok, assert_storage_noop, pallet_prelude::*, traits::ConstU32,
-    BoundedVec,
+    assert_err, assert_noop, assert_ok, assert_storage_noop, dispatch::DispatchInfo,
+    pallet_prelude::*, traits::ConstU32, BoundedVec,
 };
 use mockall::predicate;
 


### PR DESCRIPTION
This PR addresses the issue we've discovered during the code review with the too restrictive validation for the pallet bioauth extrinsics for the calls other than authenticate.