### PR TITLE
Preparations for moving `pallet-evm-balances` and `pallet-evm-system` into humanode repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,13 +4132,13 @@ dependencies = [
  "pallet-ethereum-chain-id",
  "pallet-evm",
  "pallet-evm-accounts-mapping",
- "pallet-evm-balances",
+ "pallet-evm-balances 1.0.0-dev",
  "pallet-evm-precompile-blake2",
  "pallet-evm-precompile-bn128",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
- "pallet-evm-system",
+ "pallet-evm-system 1.0.0-dev",
  "pallet-grandpa",
  "pallet-humanode-offences",
  "pallet-humanode-session",
@@ -6446,8 +6446,8 @@ dependencies = [
  "frame-system",
  "mockall",
  "pallet-balances",
- "pallet-evm-balances",
- "pallet-evm-system",
+ "pallet-evm-balances 1.0.0-dev",
+ "pallet-evm-system 1.0.0-dev",
  "parity-scale-codec",
  "primitives-currency-swap",
  "scale-info",
@@ -6466,8 +6466,8 @@ dependencies = [
  "hex-literal",
  "pallet-balances",
  "pallet-evm",
- "pallet-evm-balances",
- "pallet-evm-system",
+ "pallet-evm-balances 1.0.0-dev",
+ "pallet-evm-system 1.0.0-dev",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -6565,6 +6565,24 @@ dependencies = [
 
 [[package]]
 name = "pallet-evm-balances"
+version = "0.1.0"
+dependencies = [
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "pallet-evm",
+ "pallet-evm-system 0.1.0",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-evm-balances"
 version = "1.0.0-dev"
 source = "git+https://github.com/humanode-network/frontier?tag=locked/polkadot-v0.9.42-2025-02-08#174c0227af00dbc26485c1eac68738e1d01980e8"
 dependencies = [
@@ -6621,6 +6639,22 @@ dependencies = [
  "fp-evm",
  "ripemd",
  "sp-io",
+]
+
+[[package]]
+name = "pallet-evm-system"
+version = "0.1.0"
+dependencies = [
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "mockall",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
 ]
 
 [[package]]
@@ -7309,8 +7343,8 @@ dependencies = [
  "num_enum 0.7.3",
  "pallet-balances",
  "pallet-evm",
- "pallet-evm-balances",
- "pallet-evm-system",
+ "pallet-evm-balances 1.0.0-dev",
+ "pallet-evm-system 1.0.0-dev",
  "pallet-timestamp",
  "parity-scale-codec",
  "precompile-utils",
@@ -7350,8 +7384,8 @@ dependencies = [
  "pallet-balances",
  "pallet-erc20-support",
  "pallet-evm",
- "pallet-evm-balances",
- "pallet-evm-system",
+ "pallet-evm-balances 1.0.0-dev",
+ "pallet-evm-system 1.0.0-dev",
  "pallet-timestamp",
  "parity-scale-codec",
  "precompile-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,13 +4132,13 @@ dependencies = [
  "pallet-ethereum-chain-id",
  "pallet-evm",
  "pallet-evm-accounts-mapping",
- "pallet-evm-balances 1.0.0-dev",
+ "pallet-evm-balances",
  "pallet-evm-precompile-blake2",
  "pallet-evm-precompile-bn128",
  "pallet-evm-precompile-modexp",
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
- "pallet-evm-system 1.0.0-dev",
+ "pallet-evm-system",
  "pallet-grandpa",
  "pallet-humanode-offences",
  "pallet-humanode-session",
@@ -6446,8 +6446,8 @@ dependencies = [
  "frame-system",
  "mockall",
  "pallet-balances",
- "pallet-evm-balances 1.0.0-dev",
- "pallet-evm-system 1.0.0-dev",
+ "pallet-evm-balances",
+ "pallet-evm-system",
  "parity-scale-codec",
  "primitives-currency-swap",
  "scale-info",
@@ -6466,8 +6466,8 @@ dependencies = [
  "hex-literal",
  "pallet-balances",
  "pallet-evm",
- "pallet-evm-balances 1.0.0-dev",
- "pallet-evm-system 1.0.0-dev",
+ "pallet-evm-balances",
+ "pallet-evm-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
@@ -6571,26 +6571,12 @@ dependencies = [
  "frame-support",
  "frame-system",
  "pallet-evm",
- "pallet-evm-system 0.1.0",
+ "pallet-evm-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "sp-core",
  "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-evm-balances"
-version = "1.0.0-dev"
-source = "git+https://github.com/humanode-network/frontier?tag=locked/polkadot-v0.9.42-2025-02-08#174c0227af00dbc26485c1eac68738e1d01980e8"
-dependencies = [
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -6653,21 +6639,6 @@ dependencies = [
  "scale-info",
  "sp-core",
  "sp-io",
- "sp-runtime",
- "sp-std",
-]
-
-[[package]]
-name = "pallet-evm-system"
-version = "1.0.0-dev"
-source = "git+https://github.com/humanode-network/frontier?tag=locked/polkadot-v0.9.42-2025-02-08#174c0227af00dbc26485c1eac68738e1d01980e8"
-dependencies = [
- "fp-evm",
- "frame-support",
- "frame-system",
- "log",
- "parity-scale-codec",
- "scale-info",
  "sp-runtime",
  "sp-std",
 ]
@@ -7343,8 +7314,8 @@ dependencies = [
  "num_enum 0.7.3",
  "pallet-balances",
  "pallet-evm",
- "pallet-evm-balances 1.0.0-dev",
- "pallet-evm-system 1.0.0-dev",
+ "pallet-evm-balances",
+ "pallet-evm-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "precompile-utils",
@@ -7384,8 +7355,8 @@ dependencies = [
  "pallet-balances",
  "pallet-erc20-support",
  "pallet-evm",
- "pallet-evm-balances 1.0.0-dev",
- "pallet-evm-system 1.0.0-dev",
+ "pallet-evm-balances",
+ "pallet-evm-system",
  "pallet-timestamp",
  "parity-scale-codec",
  "precompile-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,13 +155,11 @@ fp-self-contained = { git = "https://github.com/humanode-network/frontier", tag 
 fp-storage = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
 pallet-ethereum = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
 pallet-evm = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
-pallet-evm-balances = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
 pallet-evm-precompile-blake2 = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
 pallet-evm-precompile-bn128 = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
 pallet-evm-precompile-modexp = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
 pallet-evm-precompile-sha3fips = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
 pallet-evm-precompile-simple = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
-pallet-evm-system = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
 pallet-evm-test-vector-support = { git = "https://github.com/humanode-network/frontier", tag = "locked/polkadot-v0.9.42-2025-02-08", default-features = false }
 
 [profile.release]

--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -27,6 +27,8 @@ pallet-dummy-precompiles-code = { path = "../pallet-dummy-precompiles-code", def
 pallet-erc20-support = { path = "../pallet-erc20-support", default-features = false }
 pallet-ethereum-chain-id = { path = "../pallet-ethereum-chain-id", default-features = false }
 pallet-evm-accounts-mapping = { path = "../pallet-evm-accounts-mapping", default-features = false }
+pallet-evm-balances = { path = "../pallet-evm-balances", default-features = false }
+pallet-evm-system = { path = "../pallet-evm-system", default-features = false }
 pallet-humanode-offences = { path = "../pallet-humanode-offences", default-features = false }
 pallet-humanode-session = { path = "../pallet-humanode-session", default-features = false }
 pallet-pot = { path = "../pallet-pot", default-features = false }
@@ -64,13 +66,11 @@ pallet-babe = { workspace = true }
 pallet-balances = { workspace = true }
 pallet-ethereum = { workspace = true }
 pallet-evm = { workspace = true }
-pallet-evm-balances = { workspace = true }
 pallet-evm-precompile-blake2 = { workspace = true }
 pallet-evm-precompile-bn128 = { workspace = true }
 pallet-evm-precompile-modexp = { workspace = true }
 pallet-evm-precompile-sha3fips = { workspace = true }
 pallet-evm-precompile-simple = { workspace = true }
-pallet-evm-system = { workspace = true }
 pallet-grandpa = { workspace = true }
 pallet-im-online = { workspace = true }
 pallet-multisig = { workspace = true }

--- a/crates/pallet-currency-swap/Cargo.toml
+++ b/crates/pallet-currency-swap/Cargo.toml
@@ -16,10 +16,11 @@ sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [dev-dependencies]
+pallet-evm-balances = { path = "../pallet-evm-balances", features = ["default"] }
+pallet-evm-system = { path = "../pallet-evm-system", features = ["default"] }
+
 mockall = { workspace = true }
 pallet-balances = { workspace = true, features = ["default"] }
-pallet-evm-balances = { workspace = true, features = ["default"] }
-pallet-evm-system = { workspace = true, features = ["default"] }
 sp-core = { workspace = true }
 
 [features]

--- a/crates/pallet-dummy-precompiles-code/Cargo.toml
+++ b/crates/pallet-dummy-precompiles-code/Cargo.toml
@@ -14,11 +14,12 @@ sp-core = { workspace = true }
 sp-std = { workspace = true }
 
 [dev-dependencies]
+pallet-evm-balances = { path = "../pallet-evm-balances", features = ["default"] }
+pallet-evm-system = { path = "../pallet-evm-system", features = ["default"] }
+
 fp-evm = { workspace = true }
 hex-literal = { workspace = true }
 pallet-balances = { workspace = true, features = ["default"] }
-pallet-evm-balances = { workspace = true, features = ["default"] }
-pallet-evm-system = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 
 [features]

--- a/crates/pallet-evm-balances/Cargo.toml
+++ b/crates/pallet-evm-balances/Cargo.toml
@@ -1,28 +1,22 @@
 [package]
 name = "pallet-evm-balances"
-version = "1.0.0-dev"
-license = "Apache-2.0"
-description = "FRAME EVM BALANCES pallet."
-edition = { workspace = true }
-repository = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+version = "0.1.0"
+edition = "2021"
+publish = false
 
 [dependencies]
-log = { workspace = true, default-features = false }
-scale-codec = { package = "parity-scale-codec", workspace = true }
-scale-info = { workspace = true }
-# Substrate
+codec = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+scale-info = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 
 [dev-dependencies]
+pallet-evm-system = { path = "../pallet-evm-system", features = ["default"] }
+
 fp-evm = { workspace = true }
 pallet-evm = { workspace = true }
-pallet-evm-system = { workspace = true }
 pallet-timestamp = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
@@ -30,21 +24,18 @@ sp-io = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"log/std",
-	"scale-codec/std",
-	"scale-info/std",
-	# Substrate
-	"frame-support/std",
-	"frame-system/std",
-	"pallet-timestamp/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	# Frontier
-	"fp-evm/std",
-	"pallet-evm/std",
-	"pallet-evm-system/std",
+  "codec/std",
+  "fp-evm/std",
+  "frame-support/std",
+  "frame-system/std",
+  "pallet-evm-system/std",
+  "pallet-evm/std",
+  "pallet-timestamp/std",
+  "scale-info/std",
+  "sp-runtime/std",
+  "sp-std/std",
 ]
 try-runtime = [
-	"frame-support/try-runtime",
-	"frame-system/try-runtime",
+  "frame-support/try-runtime",
+  "frame-system/try-runtime",
 ]

--- a/crates/pallet-evm-balances/Cargo.toml
+++ b/crates/pallet-evm-balances/Cargo.toml
@@ -32,10 +32,16 @@ std = [
   "pallet-evm/std",
   "pallet-timestamp/std",
   "scale-info/std",
+  "sp-core/std",
+  "sp-io/std",
   "sp-runtime/std",
   "sp-std/std",
 ]
 try-runtime = [
   "frame-support/try-runtime",
   "frame-system/try-runtime",
+  "pallet-evm-system/try-runtime",
+  "pallet-evm/try-runtime",
+  "pallet-timestamp/try-runtime",
+  "sp-runtime/try-runtime",
 ]

--- a/crates/pallet-evm-balances/src/impl_currency.rs
+++ b/crates/pallet-evm-balances/src/impl_currency.rs
@@ -131,23 +131,18 @@ where
             return (NegativeImbalance::zero(), value);
         }
 
-        let mutate_closure = |account: &mut AccountData<<T as Config<I>>::Balance>| -> Result<
-            (Self::NegativeImbalance, Self::Balance),
-            DispatchError,
-        > {
-            // Best value is the most amount we can slash following liveness rules.
-            let actual = value.min(account.free);
-            account.free.saturating_reduce(actual);
-            let remaining = value.saturating_sub(actual);
-            Ok((NegativeImbalance::new(actual), remaining))
-        };
-
-        match Self::try_mutate_account_handling_dust(
+        let result = Self::try_mutate_account_handling_dust(
             who,
             |account, _is_new| -> Result<(Self::NegativeImbalance, Self::Balance), DispatchError> {
-                mutate_closure(account)
+                // Best value is the most amount we can slash following liveness rules.
+                let actual = value.min(account.free);
+                account.free.saturating_reduce(actual);
+                let remaining = value.saturating_sub(actual);
+                Ok((NegativeImbalance::new(actual), remaining))
             },
-        ) {
+        );
+
+        match result {
             Ok((imbalance, remaining)) => {
                 Self::deposit_event(Event::Slashed {
                     who: who.clone(),

--- a/crates/pallet-evm-balances/src/lib.rs
+++ b/crates/pallet-evm-balances/src/lib.rs
@@ -5,6 +5,7 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use codec::{Codec, Decode, Encode, MaxEncodedLen};
 use frame_support::{
     ensure,
     traits::{
@@ -14,7 +15,6 @@ use frame_support::{
         StoredMap, WithdrawReasons,
     },
 };
-use scale_codec::{Codec, Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{
     traits::{Bounded, CheckedAdd, CheckedSub, MaybeSerializeDeserialize, Zero},

--- a/crates/pallet-evm-balances/src/lib.rs
+++ b/crates/pallet-evm-balances/src/lib.rs
@@ -111,65 +111,94 @@ pub mod pallet {
     pub enum Event<T: Config<I>, I: 'static = ()> {
         /// An account was created with some free balance.
         Endowed {
+            /// The associated account id.
             account: <T as Config<I>>::AccountId,
+            /// The `free_balance` balance value.
             free_balance: T::Balance,
         },
         /// An account was removed whose balance was non-zero but below ExistentialDeposit,
         /// resulting in an outright loss.
         DustLost {
+            /// The associated account id.
             account: <T as Config<I>>::AccountId,
+            /// The `amount` balance value.
             amount: T::Balance,
         },
         /// Transfer succeeded.
         Transfer {
+            /// The associated account id transferred from.
             from: <T as Config<I>>::AccountId,
+            /// The associated account id transferred to.
             to: <T as Config<I>>::AccountId,
+            /// The `amount` balance value.
             amount: T::Balance,
         },
         /// A balance was set by root.
         BalanceSet {
+            /// The associated account id.
             who: <T as Config<I>>::AccountId,
+            /// The `free` balance value.
             free: T::Balance,
         },
         /// Some amount was deposited (e.g. for transaction fees).
         Deposit {
+            /// The associated account id.
             who: <T as Config<I>>::AccountId,
+            /// The `amount` balance value.
             amount: T::Balance,
         },
         /// Some amount was withdrawn from the account (e.g. for transaction fees).
         Withdraw {
+            /// The associated account id.
             who: <T as Config<I>>::AccountId,
+            /// The `amount` balance value.
             amount: T::Balance,
         },
         /// Some amount was removed from the account (e.g. for misbehavior).
         Slashed {
+            /// The associated account id.
             who: <T as Config<I>>::AccountId,
+            /// The `amount` balance value.
             amount: T::Balance,
         },
         /// Some amount was minted into an account.
         Minted {
+            /// The associated account id.
             who: <T as Config<I>>::AccountId,
+            /// The `amount` balance value.
             amount: T::Balance,
         },
         /// Some amount was burned from an account.
         Burned {
+            /// The associated account id.
             who: <T as Config<I>>::AccountId,
+            /// The `amount` balance value.
             amount: T::Balance,
         },
         /// Some amount was suspended from an account (it can be restored later).
         Suspended {
+            /// The associated account id.
             who: <T as Config<I>>::AccountId,
+            /// The `amount` balance value.
             amount: T::Balance,
         },
         /// Some amount was restored into an account.
         Restored {
+            /// The associated account id.
             who: <T as Config<I>>::AccountId,
+            /// The `amount` balance value.
             amount: T::Balance,
         },
         /// Total issuance was increased by `amount`, creating a credit to be balanced.
-        Issued { amount: T::Balance },
+        Issued {
+            /// The `amount` balance value.
+            amount: T::Balance,
+        },
         /// Total issuance was decreased by `amount`, creating a debt to be balanced.
-        Rescinded { amount: T::Balance },
+        Rescinded {
+            /// The `amount` balance value.
+            amount: T::Balance,
+        },
     }
 
     #[pallet::error]

--- a/crates/pallet-evm-balances/src/lib.rs
+++ b/crates/pallet-evm-balances/src/lib.rs
@@ -1,8 +1,5 @@
-// SPDX-License-Identifier: Apache-2.0
-
 //! # EVM Balances Pallet.
 
-// Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Codec, Decode, Encode, MaxEncodedLen};

--- a/crates/pallet-evm-balances/src/lib.rs
+++ b/crates/pallet-evm-balances/src/lib.rs
@@ -38,6 +38,9 @@ pub use pallet::*;
 /// The current storage version.
 const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
 
+// We have to temporarily allow some clippy lints. Later on we'll send patches to substrate to
+// fix them at their end.
+#[allow(clippy::missing_docs_in_private_items)]
 #[frame_support::pallet]
 pub mod pallet {
     use frame_support::pallet_prelude::*;

--- a/crates/pallet-evm-balances/src/mock.rs
+++ b/crates/pallet-evm-balances/src/mock.rs
@@ -1,22 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-// This file is part of Frontier.
-//
-// Copyright (c) 2020-2022 Parity Technologies (UK) Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-//! Test mock for unit tests.
-
 use std::collections::BTreeMap;
 
 use frame_support::{

--- a/crates/pallet-evm-balances/src/tests/currency.rs
+++ b/crates/pallet-evm-balances/src/tests/currency.rs
@@ -123,7 +123,7 @@ fn transfer_works() {
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
 
-        let transfered_amount = 100;
+        let transferred_amount = 100;
 
         // Set block number to enable events.
         System::set_block_number(1);
@@ -132,23 +132,23 @@ fn transfer_works() {
         assert_ok!(EvmBalances::transfer(
             &alice(),
             &bob(),
-            transfered_amount,
+            transferred_amount,
             ExistenceRequirement::KeepAlive
         ));
 
         // Assert state changes.
         assert_eq!(
             EvmBalances::total_balance(&alice()),
-            INIT_BALANCE - transfered_amount
+            INIT_BALANCE - transferred_amount
         );
         assert_eq!(
             EvmBalances::total_balance(&bob()),
-            INIT_BALANCE + transfered_amount
+            INIT_BALANCE + transferred_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Transfer {
             from: alice(),
             to: bob(),
-            amount: transfered_amount,
+            amount: transferred_amount,
         }));
 
         assert_total_issuance_invariant();
@@ -161,7 +161,7 @@ fn transfer_works_full_balance() {
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
 
-        let transfered_amount = INIT_BALANCE;
+        let transferred_amount = INIT_BALANCE;
 
         // Set block number to enable events.
         System::set_block_number(1);
@@ -170,23 +170,23 @@ fn transfer_works_full_balance() {
         assert_ok!(EvmBalances::transfer(
             &alice(),
             &bob(),
-            transfered_amount,
+            transferred_amount,
             ExistenceRequirement::AllowDeath
         ));
 
         // Assert state changes.
         assert_eq!(
             EvmBalances::total_balance(&alice()),
-            INIT_BALANCE - transfered_amount
+            INIT_BALANCE - transferred_amount
         );
         assert_eq!(
             EvmBalances::total_balance(&bob()),
-            INIT_BALANCE + transfered_amount
+            INIT_BALANCE + transferred_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Transfer {
             from: alice(),
             to: bob(),
-            amount: transfered_amount,
+            amount: transferred_amount,
         }));
         assert!(!EvmSystem::account_exists(&alice()));
         System::assert_has_event(RuntimeEvent::EvmSystem(
@@ -203,7 +203,7 @@ fn transfer_fails_funds_unavailable() {
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
 
-        let transfered_amount = INIT_BALANCE + 1;
+        let transferred_amount = INIT_BALANCE + 1;
 
         // Set block number to enable events.
         System::set_block_number(1);
@@ -213,7 +213,7 @@ fn transfer_fails_funds_unavailable() {
             EvmBalances::transfer(
                 &alice(),
                 &bob(),
-                transfered_amount,
+                transferred_amount,
                 ExistenceRequirement::KeepAlive
             ),
             TokenError::FundsUnavailable
@@ -227,7 +227,7 @@ fn transfer_fails_not_expendable() {
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
 
-        let transfered_amount = INIT_BALANCE;
+        let transferred_amount = INIT_BALANCE;
 
         // Set block number to enable events.
         System::set_block_number(1);
@@ -237,7 +237,7 @@ fn transfer_fails_not_expendable() {
             EvmBalances::transfer(
                 &alice(),
                 &bob(),
-                transfered_amount,
+                transferred_amount,
                 ExistenceRequirement::KeepAlive
             ),
             TokenError::NotExpendable

--- a/crates/pallet-evm-balances/src/tests/currency.rs
+++ b/crates/pallet-evm-balances/src/tests/currency.rs
@@ -27,7 +27,7 @@ fn total_balance_works() {
 fn free_balance_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check the free balance value.
-        assert_eq!(EvmBalances::free_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::free_balance(alice()), INIT_BALANCE);
     });
 }
 
@@ -551,7 +551,7 @@ fn evm_system_account_should_be_reaped() {
         ));
 
         // Assert state changes.
-        assert_eq!(EvmBalances::free_balance(&bob()), 0);
+        assert_eq!(EvmBalances::free_balance(bob()), 0);
         assert!(!EvmSystem::account_exists(&bob()));
         System::assert_has_event(RuntimeEvent::EvmSystem(
             pallet_evm_system::Event::KilledAccount { account: bob() },

--- a/crates/pallet-evm-balances/src/tests/fungible.rs
+++ b/crates/pallet-evm-balances/src/tests/fungible.rs
@@ -683,7 +683,7 @@ fn transfer_works() {
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
 
-        let transfered_amount = 100;
+        let transferred_amount = 100;
 
         // Set block number to enable events.
         System::set_block_number(1);
@@ -692,23 +692,23 @@ fn transfer_works() {
         assert_ok!(EvmBalances::transfer(
             &alice(),
             &bob(),
-            transfered_amount,
+            transferred_amount,
             Preservation::Preserve
         ));
 
         // Assert state changes.
         assert_eq!(
             EvmBalances::total_balance(&alice()),
-            INIT_BALANCE - transfered_amount
+            INIT_BALANCE - transferred_amount
         );
         assert_eq!(
             EvmBalances::total_balance(&bob()),
-            INIT_BALANCE + transfered_amount
+            INIT_BALANCE + transferred_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Transfer {
             from: alice(),
             to: bob(),
-            amount: transfered_amount,
+            amount: transferred_amount,
         }));
 
         assert_total_issuance_invariant();
@@ -721,7 +721,7 @@ fn transfer_works_full_balance() {
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
 
-        let transfered_amount = INIT_BALANCE;
+        let transferred_amount = INIT_BALANCE;
 
         // Set block number to enable events.
         System::set_block_number(1);
@@ -730,23 +730,23 @@ fn transfer_works_full_balance() {
         assert_ok!(EvmBalances::transfer(
             &alice(),
             &bob(),
-            transfered_amount,
+            transferred_amount,
             Preservation::Expendable
         ));
 
         // Assert state changes.
         assert_eq!(
             EvmBalances::total_balance(&alice()),
-            INIT_BALANCE - transfered_amount
+            INIT_BALANCE - transferred_amount
         );
         assert_eq!(
             EvmBalances::total_balance(&bob()),
-            INIT_BALANCE + transfered_amount
+            INIT_BALANCE + transferred_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Transfer {
             from: alice(),
             to: bob(),
-            amount: transfered_amount,
+            amount: transferred_amount,
         }));
         assert!(!EvmSystem::account_exists(&alice()));
         System::assert_has_event(RuntimeEvent::EvmSystem(
@@ -763,14 +763,14 @@ fn transfer_fails_funds_unavailable() {
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
 
-        let transfered_amount = INIT_BALANCE + 1;
+        let transferred_amount = INIT_BALANCE + 1;
 
         // Set block number to enable events.
         System::set_block_number(1);
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::transfer(&alice(), &bob(), transfered_amount, Preservation::Preserve),
+            EvmBalances::transfer(&alice(), &bob(), transferred_amount, Preservation::Preserve),
             TokenError::FundsUnavailable
         );
     });
@@ -782,14 +782,14 @@ fn transfer_fails_not_expendable() {
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
 
-        let transfered_amount = INIT_BALANCE;
+        let transferred_amount = INIT_BALANCE;
 
         // Set block number to enable events.
         System::set_block_number(1);
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::transfer(&alice(), &bob(), transfered_amount, Preservation::Preserve),
+            EvmBalances::transfer(&alice(), &bob(), transferred_amount, Preservation::Preserve),
             TokenError::NotExpendable
         );
     });

--- a/crates/pallet-evm-balances/src/tests/mod.rs
+++ b/crates/pallet-evm-balances/src/tests/mod.rs
@@ -53,13 +53,13 @@ fn evm_system_removing_account_non_zero_balance() {
             ExistenceRequirement::KeepAlive
         ));
 
-        assert_eq!(EvmBalances::free_balance(&contract), 1000);
+        assert_eq!(EvmBalances::free_balance(contract), 1000);
 
         // Invoke the function under test.
         EVM::remove_account(&contract);
 
         // Assert state changes.
-        assert_eq!(EvmBalances::free_balance(&contract), 1000);
+        assert_eq!(EvmBalances::free_balance(contract), 1000);
         assert!(EvmSystem::account_exists(&contract));
 
         assert_total_issuance_invariant();
@@ -73,7 +73,7 @@ fn evm_fee_deduction() {
 
 		// Seed account
 		let _ = <Test as pallet_evm::Config>::Currency::deposit_creating(&charlie, 100);
-		assert_eq!(EvmBalances::free_balance(&charlie), 100);
+		assert_eq!(EvmBalances::free_balance(charlie), 100);
 
 		// Deduct fees as 10 units
 		let imbalance =
@@ -82,11 +82,11 @@ fn evm_fee_deduction() {
 				U256::from(10),
 			)
 			.unwrap();
-		assert_eq!(EvmBalances::free_balance(&charlie), 90);
+		assert_eq!(EvmBalances::free_balance(charlie), 90);
 
 		// Refund fees as 5 units
 		<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&charlie, U256::from(5), U256::from(5), imbalance);
-		assert_eq!(EvmBalances::free_balance(&charlie), 95);
+		assert_eq!(EvmBalances::free_balance(charlie), 95);
 
 		assert_total_issuance_invariant();
 	});
@@ -202,7 +202,7 @@ fn evm_refunds_and_priority_should_work() {
 
         let (base_fee, _) = <Test as pallet_evm::Config>::FeeCalculator::min_gas_price();
         let actual_tip = (max_fee_per_gas - base_fee).min(tip) * used_gas;
-        let total_cost = (used_gas * base_fee) + U256::from(actual_tip) + U256::from(1);
+        let total_cost = (used_gas * base_fee) + actual_tip + U256::from(1);
         let after_call = EVM::account_basic(&alice()).0.balance;
         // The tip is deducted but never refunded to the caller.
         assert_eq!(after_call, before_call - total_cost);

--- a/crates/pallet-evm-balances/src/tests/mod.rs
+++ b/crates/pallet-evm-balances/src/tests/mod.rs
@@ -1,4 +1,4 @@
-//! Unit tests.
+//! The tests for the pallet.
 
 use frame_support::{assert_ok, traits::Currency, weights::Weight};
 use pallet_evm::{FeeCalculator, FixedGasWeightMapping, GasWeightMapping, Runner};

--- a/crates/pallet-evm-system/Cargo.toml
+++ b/crates/pallet-evm-system/Cargo.toml
@@ -26,10 +26,13 @@ std = [
   "frame-support/std",
   "frame-system/std",
   "scale-info/std",
+  "sp-core/std",
+  "sp-io/std",
   "sp-runtime/std",
   "sp-std/std",
 ]
 try-runtime = [
   "frame-support/try-runtime",
   "frame-system/try-runtime",
+  "sp-runtime/try-runtime",
 ]

--- a/crates/pallet-evm-system/Cargo.toml
+++ b/crates/pallet-evm-system/Cargo.toml
@@ -1,25 +1,17 @@
 [package]
 name = "pallet-evm-system"
-version = "1.0.0-dev"
-license = "Apache-2.0"
-description = "FRAME EVM SYSTEM pallet."
-edition = { workspace = true }
-repository = { workspace = true }
-
-[package.metadata.docs.rs]
-targets = ["x86_64-unknown-linux-gnu"]
+version = "0.1.0"
+edition = "2021"
+publish = false
 
 [dependencies]
-log = { workspace = true, default-features = false }
-scale-codec = { package = "parity-scale-codec", workspace = true }
-scale-info = { workspace = true }
-# Substrate
+codec = { workspace = true }
+fp-evm = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
+scale-info = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
-# Frontier
-fp-evm = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }
@@ -29,18 +21,15 @@ sp-io = { workspace = true }
 [features]
 default = ["std"]
 std = [
-	"log/std",
-	"scale-codec/std",
-	"scale-info/std",
-	# Substrate
-	"frame-support/std",
-	"frame-system/std",
-	"sp-runtime/std",
-	"sp-std/std",
-	# Frontier
-  	"fp-evm/std",
+  "codec/std",
+  "fp-evm/std",
+  "frame-support/std",
+  "frame-system/std",
+  "scale-info/std",
+  "sp-runtime/std",
+  "sp-std/std",
 ]
 try-runtime = [
-	"frame-support/try-runtime",
-	"frame-system/try-runtime",
+  "frame-support/try-runtime",
+  "frame-system/try-runtime",
 ]

--- a/crates/pallet-evm-system/src/lib.rs
+++ b/crates/pallet-evm-system/src/lib.rs
@@ -3,8 +3,8 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use codec::{Decode, Encode, FullCodec, MaxEncodedLen};
 use frame_support::traits::StoredMap;
-use scale_codec::{Decode, Encode, FullCodec, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sp_runtime::{
     traits::{One, Zero},

--- a/crates/pallet-evm-system/src/lib.rs
+++ b/crates/pallet-evm-system/src/lib.rs
@@ -144,8 +144,8 @@ impl<T: Config> Pallet<T> {
         let is_new_account = Account::<T>::mutate_exists(who, |maybe_account| {
             let is_new_account = maybe_account.is_none();
 
-			let account = maybe_account.get_or_insert_with(Default::default);
-			// `AtLeast32Bit` is big enough for this overflow to be practically impossible.
+            let account = maybe_account.get_or_insert_with(Default::default);
+            // `AtLeast32Bit` is big enough for this overflow to be practically impossible.
             account.nonce = account.nonce.saturating_add(<T as Config>::Index::one());
 
             is_new_account

--- a/crates/pallet-evm-system/src/lib.rs
+++ b/crates/pallet-evm-system/src/lib.rs
@@ -1,6 +1,5 @@
 //! # EVM System Pallet.
 
-// Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use codec::{Decode, Encode, FullCodec, MaxEncodedLen};

--- a/crates/pallet-evm-system/src/lib.rs
+++ b/crates/pallet-evm-system/src/lib.rs
@@ -95,9 +95,15 @@ pub mod pallet {
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
         /// A new account was created.
-        NewAccount { account: <T as Config>::AccountId },
+        NewAccount {
+            /// The associated account id.
+            account: <T as Config>::AccountId,
+        },
         /// An account was reaped.
-        KilledAccount { account: <T as Config>::AccountId },
+        KilledAccount {
+            /// The associated account id.
+            account: <T as Config>::AccountId,
+        },
     }
 }
 

--- a/crates/pallet-evm-system/src/lib.rs
+++ b/crates/pallet-evm-system/src/lib.rs
@@ -27,6 +27,9 @@ pub struct AccountInfo<Index, AccountData> {
     pub data: AccountData,
 }
 
+// We have to temporarily allow some clippy lints. Later on we'll send patches to substrate to
+// fix them at their end.
+#[allow(clippy::missing_docs_in_private_items)]
 #[frame_support::pallet]
 pub mod pallet {
     use frame_support::pallet_prelude::*;

--- a/crates/pallet-evm-system/src/lib.rs
+++ b/crates/pallet-evm-system/src/lib.rs
@@ -7,7 +7,7 @@ use frame_support::traits::StoredMap;
 use scale_info::TypeInfo;
 use sp_runtime::{
     traits::{One, Zero},
-    DispatchError, RuntimeDebug,
+    DispatchError, RuntimeDebug, Saturating,
 };
 
 #[cfg(test)]
@@ -145,7 +145,8 @@ impl<T: Config> Pallet<T> {
             let is_new_account = maybe_account.is_none();
 
 			let account = maybe_account.get_or_insert_with(Default::default);
-			account.nonce += <T as Config>::Index::one();
+			// `AtLeast32Bit` is big enough for this overflow to be practically impossible.
+            account.nonce = account.nonce.saturating_add(<T as Config>::Index::one());
 
             is_new_account
         });

--- a/crates/pallet-evm-system/src/mock.rs
+++ b/crates/pallet-evm-system/src/mock.rs
@@ -1,22 +1,3 @@
-// SPDX-License-Identifier: Apache-2.0
-// This file is part of Frontier.
-//
-// Copyright (c) 2020-2022 Parity Technologies (UK) Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-// 	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
-//! Test mock for unit tests.
-
 use frame_support::traits::{ConstU32, ConstU64};
 use mockall::mock;
 use sp_core::{H160, H256};

--- a/crates/pallet-evm-system/src/tests.rs
+++ b/crates/pallet-evm-system/src/tests.rs
@@ -1,4 +1,4 @@
-//! Unit tests.
+//! The tests for the pallet.
 
 use frame_support::{assert_noop, assert_storage_noop};
 use mockall::predicate;

--- a/crates/pallet-evm-system/src/tests.rs
+++ b/crates/pallet-evm-system/src/tests.rs
@@ -38,7 +38,7 @@ fn create_account_created() {
         // Assert state changes.
         assert!(EvmSystem::account_exists(&account_id));
         assert_eq!(
-            <Account<Test>>::get(&account_id),
+            <Account<Test>>::get(account_id),
             AccountInfo::<_, _>::default()
         );
         System::assert_has_event(RuntimeEvent::EvmSystem(Event::NewAccount {
@@ -57,7 +57,7 @@ fn create_account_already_exists() {
     new_test_ext().execute_with_ext(|_| {
         // Prepare test data.
         let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
-        <Account<Test>>::insert(account_id.clone(), AccountInfo::<_, _>::default());
+        <Account<Test>>::insert(account_id, AccountInfo::<_, _>::default());
 
         // Invoke the function under test.
         assert_storage_noop!(assert_eq!(
@@ -119,7 +119,7 @@ fn inc_account_nonce_account_exists() {
     new_test_ext().execute_with_ext(|_| {
         // Prepare test data.
         let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
-        <Account<Test>>::insert(account_id.clone(), AccountInfo::<_, _>::default());
+        <Account<Test>>::insert(account_id, AccountInfo::<_, _>::default());
 
         // Check test preconditions.
         assert!(EvmSystem::account_exists(&account_id));
@@ -135,7 +135,7 @@ fn inc_account_nonce_account_exists() {
     });
 }
 
-/// This test verifies that try_mutate_exists works as expected in case data wasn't providing
+/// This test verifies that `try_mutate_exists` works as expected in case data wasn't providing
 /// and returned data is `Some`. As a result, a new account has been created.
 #[test]
 fn try_mutate_exists_account_created() {
@@ -167,7 +167,7 @@ fn try_mutate_exists_account_created() {
         // Assert state changes.
         assert!(EvmSystem::account_exists(&account_id));
         assert_eq!(
-            <Account<Test>>::get(&account_id),
+            <Account<Test>>::get(account_id),
             AccountInfo {
                 data: 1,
                 ..Default::default()
@@ -182,7 +182,7 @@ fn try_mutate_exists_account_created() {
     });
 }
 
-/// This test verifies that try_mutate_exists works as expected in case data was providing
+/// This test verifies that `try_mutate_exists` works as expected in case data was providing
 /// and returned data is `Some`. As a result, the account has been updated.
 #[test]
 fn try_mutate_exists_account_updated() {
@@ -191,7 +191,7 @@ fn try_mutate_exists_account_updated() {
         let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
         let nonce = 1;
         let data = 1;
-        <Account<Test>>::insert(account_id.clone(), AccountInfo { nonce, data });
+        <Account<Test>>::insert(account_id, AccountInfo { nonce, data });
 
         // Check test preconditions.
         assert!(EvmSystem::account_exists(&account_id));
@@ -211,7 +211,7 @@ fn try_mutate_exists_account_updated() {
         // Assert state changes.
         assert!(EvmSystem::account_exists(&account_id));
         assert_eq!(
-            <Account<Test>>::get(&account_id),
+            <Account<Test>>::get(account_id),
             AccountInfo {
                 nonce,
                 data: data + 1,
@@ -220,14 +220,14 @@ fn try_mutate_exists_account_updated() {
     });
 }
 
-/// This test verifies that try_mutate_exists works as expected in case data was providing
+/// This test verifies that `try_mutate_exists` works as expected in case data was providing
 /// and returned data is `None`, account has zero nonce. As a result, the account has been removed.
 #[test]
 fn try_mutate_exists_account_removed() {
     new_test_ext().execute_with_ext(|_| {
         // Prepare test data.
         let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
-        <Account<Test>>::insert(account_id.clone(), AccountInfo::<_, _>::default());
+        <Account<Test>>::insert(account_id, AccountInfo::<_, _>::default());
 
         // Check test preconditions.
         assert!(EvmSystem::account_exists(&account_id));
@@ -261,7 +261,7 @@ fn try_mutate_exists_account_removed() {
     });
 }
 
-/// This test verifies that try_mutate_exists works as expected in case data was providing
+/// This test verifies that `try_mutate_exists` works as expected in case data was providing
 /// and returned data is `None`, account has non zero nonce. As a result, the account has been retained.
 #[test]
 fn try_mutate_exists_account_retained() {
@@ -272,7 +272,7 @@ fn try_mutate_exists_account_retained() {
         let data = 100;
 
         let account_info = AccountInfo { nonce, data };
-        <Account<Test>>::insert(account_id.clone(), account_info);
+        <Account<Test>>::insert(account_id, account_info);
 
         // Check test preconditions.
         assert!(EvmSystem::account_exists(&account_id));
@@ -287,7 +287,7 @@ fn try_mutate_exists_account_retained() {
         // Assert state changes.
         assert!(EvmSystem::account_exists(&account_id));
         assert_eq!(
-            <Account<Test>>::get(&account_id),
+            <Account<Test>>::get(account_id),
             AccountInfo {
                 nonce,
                 ..Default::default()
@@ -296,7 +296,7 @@ fn try_mutate_exists_account_retained() {
     });
 }
 
-/// This test verifies that try_mutate_exists works as expected in case data wasn't providing
+/// This test verifies that `try_mutate_exists` works as expected in case data wasn't providing
 /// and returned data is `None`. As a result, the account hasn't been created.
 #[test]
 fn try_mutate_exists_account_not_created() {
@@ -322,14 +322,14 @@ fn try_mutate_exists_account_not_created() {
     });
 }
 
-/// This test verifies that try_mutate_exists works as expected in case getting error
+/// This test verifies that `try_mutate_exists` works as expected in case getting error
 /// during data mutation.
 #[test]
 fn try_mutate_exists_without_changes() {
     new_test_ext().execute_with_ext(|_| {
         // Prepare test data.
         let account_id = H160::from_str("1000000000000000000000000000000000000001").unwrap();
-        <Account<Test>>::insert(account_id.clone(), AccountInfo::<_, _>::default());
+        <Account<Test>>::insert(account_id, AccountInfo::<_, _>::default());
 
         // Check test preconditions.
         assert!(EvmSystem::account_exists(&account_id));

--- a/crates/precompile-currency-swap/Cargo.toml
+++ b/crates/precompile-currency-swap/Cargo.toml
@@ -17,13 +17,14 @@ scale-info = { workspace = true, features = ["derive"] }
 sp-core = { workspace = true }
 
 [dev-dependencies]
+pallet-evm-balances = { path = "../pallet-evm-balances", features = ["default"] }
+pallet-evm-system = { path = "../pallet-evm-system", features = ["default"] }
+
 frame-system = { workspace = true }
 hex-literal = { workspace = true }
 mockall = { workspace = true }
 pallet-balances = { workspace = true, features = ["default"] }
 pallet-evm = { workspace = true }
-pallet-evm-balances = { workspace = true, features = ["default"] }
-pallet-evm-system = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 
 [features]

--- a/crates/precompile-native-currency/Cargo.toml
+++ b/crates/precompile-native-currency/Cargo.toml
@@ -6,6 +6,7 @@ publish = false
 
 [dependencies]
 pallet-erc20-support = { path = "../pallet-erc20-support", default-features = false }
+pallet-evm-balances = { path = "../pallet-evm-balances", default-features = false }
 precompile-utils = { path = "../precompile-utils", default-features = false }
 
 codec = { workspace = true, features = ["derive"] }
@@ -13,18 +14,17 @@ fp-evm = { workspace = true }
 frame-support = { workspace = true }
 num_enum = { workspace = true }
 pallet-evm = { workspace = true }
-pallet-evm-balances = { workspace = true }
 scale-info = { workspace = true, features = ["derive"] }
 sp-core = { workspace = true }
 
 [dev-dependencies]
+pallet-evm-system = { path = "../pallet-evm-system", features = ["default"] }
 precompile-utils = { path = "../precompile-utils", features = ["testing"] }
 
 frame-system = { workspace = true }
 hex-literal = { workspace = true }
 pallet-balances = { workspace = true, features = ["default"] }
 pallet-evm = { workspace = true }
-pallet-evm-system = { workspace = true, features = ["default"] }
 pallet-timestamp = { workspace = true, features = ["default"] }
 
 [features]

--- a/utils/checks/snapshots/features.yaml
+++ b/utils/checks/snapshots/features.yaml
@@ -2176,7 +2176,7 @@
     - default
     - frame-benchmarking
     - std
-- name: pallet-evm-balances 1.0.0-dev
+- name: pallet-evm-balances 0.1.0
   features:
     - default
     - std
@@ -2195,7 +2195,7 @@
 - name: pallet-evm-precompile-simple 2.0.0-dev
   features:
     - std
-- name: pallet-evm-system 1.0.0-dev
+- name: pallet-evm-system 0.1.0
   features:
     - default
     - std


### PR DESCRIPTION
A part of #1430 

Decided to separate PRs containing simple code movement and some improvements that should be done at humanode repo before merging #1430 into master:
- adding missing docs
- proper crates usage
- features and features-snapshot
- fixing general clippy
- fixing clippy related to `arithmetic_side_effects`
- remove licenses used at frontier fork and apply humanode repo license (@quasiyoke asked a good question: are we eligible to do it in a such way?)