### PR TITLE
Remove migrations used to properly initialize storage versions at `humanode-runtime`

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -881,13 +881,6 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (
-        storage_version_initializer::StorageVersionInitializer<DummyPrecompilesCode, Runtime>,
-        storage_version_initializer::StorageVersionInitializer<
-            BalancedCurrencySwapBridgesInitializer,
-            Runtime,
-        >,
-    ),
 >;
 
 impl frame_system::offchain::CreateSignedTransaction<RuntimeCall> for Runtime {


### PR DESCRIPTION
Storage versions have been properly initialized for `pallet-dummy-precompiles-code` and `pallet-balanced-currency-swap-bridges-initializer` at mainnet with latest runtime upgrade to 123 `spec_version`

<img width="1418" alt="Screenshot 2025-02-10 at 10 33 06" src="https://github.com/user-attachments/assets/7c0d19d6-cd19-43b1-8774-99587e6a5b4c" />
