### PR TITLE
Clear all storage items associated with removed Offences pallet at runtime level

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -874,6 +874,10 @@ pub type UncheckedExtrinsic =
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 
+parameter_types! {
+    pub const Offences: &'static str = "Offences";
+}
+
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
     Runtime,
@@ -881,6 +885,7 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
+    (frame_support::migrations::RemovePallet<Offences, RocksDbWeight>,),
 >;
 
 impl frame_system::offchain::CreateSignedTransaction<RuntimeCall> for Runtime {

--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -875,6 +875,7 @@ pub type UncheckedExtrinsic =
 pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 
 parameter_types! {
+    /// A static string representing already removed offences pallet name.
     pub const Offences: &'static str = "Offences";
 }
 


### PR DESCRIPTION
Done using [RemovePallet](https://github.com/paritytech/substrate/blob/033d4e86cc7eff0066cd376b9375f815761d653c/frame/support/src/migrations.rs#L298)

`try-runtime` run over mainnet:
```
2025-02-10 17:57:06.354  INFO main frame_support::migrations: Found Offences keys pre-removal 👀    
2025-02-10 17:57:06.481  INFO main frame_support::migrations: Removed 80814 Offences keys 🧹    
2025-02-10 17:57:06.819  INFO main frame_support::migrations: No Offences keys found post-removal 🎉 
```