### PR TITLE
Implement migration logic to clean consumed auth ticket nonces at `pallet-bioauth`

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -886,7 +886,10 @@ pub type Executive = frame_executive::Executive<
     frame_system::ChainContext<Runtime>,
     Runtime,
     AllPalletsWithSystem,
-    (frame_support::migrations::RemovePallet<Offences, RocksDbWeight>,),
+    (
+        frame_support::migrations::RemovePallet<Offences, RocksDbWeight>,
+        pallet_bioauth::migrations::consumed_auth_ticket_nonces_cleaner::ConsumedAuthTicketNoncesCleaner<Runtime>,
+    ),
 >;
 
 impl frame_system::offchain::CreateSignedTransaction<RuntimeCall> for Runtime {

--- a/crates/pallet-bioauth/src/lib.rs
+++ b/crates/pallet-bioauth/src/lib.rs
@@ -23,6 +23,7 @@ pub use weights::*;
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 pub mod weights;
+pub mod migrations;
 
 #[cfg(test)]
 mod mock;

--- a/crates/pallet-bioauth/src/lib.rs
+++ b/crates/pallet-bioauth/src/lib.rs
@@ -22,8 +22,8 @@ pub use weights::*;
 
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
-pub mod weights;
 pub mod migrations;
+pub mod weights;
 
 #[cfg(test)]
 mod mock;

--- a/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
+++ b/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
@@ -40,6 +40,8 @@ impl<T: Config> OnRuntimeUpgrade for ConsumedAuthTicketNoncesCleaner<T> {
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+        // Record the current generation value based on latest added nonce value,
+        // otherwise return an empty result if there are no nonces yet.
         let pre_upgrade_state = match ConsumedAuthTicketNonces::<T>::get().last() {
             Some(last_consumed_auth_ticket_nonce) => {
                 last_consumed_auth_ticket_nonce.clone()[..16].to_vec()

--- a/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
+++ b/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
@@ -63,7 +63,7 @@ impl<T: Config> OnRuntimeUpgrade for ConsumedAuthTicketNoncesCleaner<T> {
         let consumed_auth_ticket_nonces = ConsumedAuthTicketNonces::<T>::get();
 
         ensure!(
-            last_consumed_auth_ticket_nonce == consumed_auth_ticket_nonces.last().unwrap().to_vec(),
+            last_consumed_auth_ticket_nonce == consumed_auth_ticket_nonces.last().unwrap()[..],
             "The last record we selected earlier should remain in it's position of being last"
         );
 

--- a/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
+++ b/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
@@ -16,6 +16,7 @@ impl<T: Config> OnRuntimeUpgrade for ConsumedAuthTicketNoncesCleaner<T> {
 
         ConsumedAuthTicketNonces::<T>::mutate(|consumed_auth_ticket_nonces| {
             if let Some(last_consumed_auth_ticket_nonce) = consumed_auth_ticket_nonces.last() {
+                // Current generation is represented by first 16 bytes at nonce.
                 let current_generation = last_consumed_auth_ticket_nonce[..16].to_vec();
 
                 consumed_auth_ticket_nonces.retain(|consumed_auth_ticket_nonce| {

--- a/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
+++ b/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
@@ -19,7 +19,8 @@ impl<T: Config> OnRuntimeUpgrade for ConsumedAuthTicketNoncesCleaner<T> {
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
-        todo!()
+        // Do nothing.
+        Ok(Vec::new())
     }
 
     #[cfg(feature = "try-runtime")]

--- a/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
+++ b/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
@@ -1,0 +1,4 @@
+//! Migration to clean consumed auth ticket nonces.
+
+/// Execute migration to clean consumed auth ticket nonces.
+pub struct ConsumedAuthTicketNoncesCleaner<T>(sp_std::marker::PhantomData<T>);

--- a/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
+++ b/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
@@ -4,7 +4,7 @@
 use frame_support::sp_std::vec::Vec;
 use frame_support::{log::info, pallet_prelude::*, traits::OnRuntimeUpgrade};
 
-use crate::{Config, Pallet};
+use crate::{Config, ConsumedAuthTicketNonces, Pallet};
 
 /// Execute migration to clean consumed auth ticket nonces.
 pub struct ConsumedAuthTicketNoncesCleaner<T>(sp_std::marker::PhantomData<T>);
@@ -14,7 +14,13 @@ impl<T: Config> OnRuntimeUpgrade for ConsumedAuthTicketNoncesCleaner<T> {
         let pallet_name = Pallet::<T>::name();
         info!("{pallet_name}: Running migration to clean consumed auth ticket nonces");
 
-        todo!()
+        ConsumedAuthTicketNonces::<T>::mutate(|consumed_auth_ticket_nonces| {
+            consumed_auth_ticket_nonces.clear();
+        });
+
+        info!("{pallet_name}: Migrated");
+
+        T::DbWeight::get().reads_writes(1, 1)
     }
 
     #[cfg(feature = "try-runtime")]
@@ -25,6 +31,11 @@ impl<T: Config> OnRuntimeUpgrade for ConsumedAuthTicketNoncesCleaner<T> {
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
-        todo!()
+        ensure!(
+            ConsumedAuthTicketNonces::<T>::decode_len().unwrap() == 0,
+            "Consumed auth ticket nonces should be empty",
+        );
+
+        Ok(())
     }
 }

--- a/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
+++ b/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
@@ -1,4 +1,29 @@
 //! Migration to clean consumed auth ticket nonces.
 
+#[cfg(feature = "try-runtime")]
+use frame_support::sp_std::vec::Vec;
+use frame_support::{log::info, pallet_prelude::*, traits::OnRuntimeUpgrade};
+
+use crate::{Config, Pallet};
+
 /// Execute migration to clean consumed auth ticket nonces.
 pub struct ConsumedAuthTicketNoncesCleaner<T>(sp_std::marker::PhantomData<T>);
+
+impl<T: Config> OnRuntimeUpgrade for ConsumedAuthTicketNoncesCleaner<T> {
+    fn on_runtime_upgrade() -> Weight {
+        let pallet_name = Pallet::<T>::name();
+        info!("{pallet_name}: Running migration to clean consumed auth ticket nonces");
+
+        todo!()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+        todo!()
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
+        todo!()
+    }
+}

--- a/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
+++ b/crates/pallet-bioauth/src/migrations/consumed_auth_ticket_nonces_cleaner.rs
@@ -15,6 +15,8 @@ impl<T: Config> OnRuntimeUpgrade for ConsumedAuthTicketNoncesCleaner<T> {
         info!("{pallet_name}: Running migration to clean consumed auth ticket nonces");
 
         ConsumedAuthTicketNonces::<T>::mutate(|consumed_auth_ticket_nonces| {
+            let consumed_auth_ticket_nonces_number_before = consumed_auth_ticket_nonces.len();
+
             if let Some(last_consumed_auth_ticket_nonce) = consumed_auth_ticket_nonces.last() {
                 // Current generation is represented by first 16 bytes at nonce.
                 let current_generation = last_consumed_auth_ticket_nonce[..16].to_vec();
@@ -23,6 +25,12 @@ impl<T: Config> OnRuntimeUpgrade for ConsumedAuthTicketNoncesCleaner<T> {
                     consumed_auth_ticket_nonce.starts_with(&current_generation)
                 });
             }
+
+            let removed_number = consumed_auth_ticket_nonces_number_before
+                .checked_sub(consumed_auth_ticket_nonces.len())
+                .expect("valid operation; qed");
+
+            info!("{pallet_name}: Removed {removed_number} consumed auth ticket nonces");
         });
 
         info!("{pallet_name}: Migrated");

--- a/crates/pallet-bioauth/src/migrations/mod.rs
+++ b/crates/pallet-bioauth/src/migrations/mod.rs
@@ -1,0 +1,3 @@
+//! Storage migrations.
+
+pub mod consumed_auth_ticket_nonces_cleaner;


### PR DESCRIPTION
Successfully executed sudo runtime upgrade transaction using patched fork based on `11509363` block.

#### before upgrade

<img width="1440" alt="Screenshot 2025-02-12 at 14 57 59" src="https://github.com/user-attachments/assets/a91b097c-3f46-4286-a40c-617463ee2777" />


#### logs during upgrade
```
2025-02-12 14:58:42 🙌 Starting consensus session on top of parent 0x7b62c0b23ebd689e1a6d6fafbf85e1e390c390739310806b45148a80f2a20c9b    
2025-02-12 14:58:42 🎁 Prepared block for proposing at 9 (4619 ms) [hash: 0x7567e9d759705e0ecc735243e93585f63302b3c501f3bc1e092340188dea78e4; parent_hash: 0x7b62…0c9b; extrinsics (1): [0xa33e…eb74]]    
2025-02-12 14:58:43 💤 Idle (0 peers), best: #8 (0x7b62…0c9b), finalized #0 (0x2bb9…85ba), ⬇ 0 ⬆ 0    
2025-02-12 14:58:43 Removed 80814 Offences keys 🧹    
2025-02-12 14:58:43 Bioauth: Running migration to clean consumed auth ticket nonces except ones related to current generation    
2025-02-12 14:58:43 Bioauth: Removed 47908 consumed auth ticket nonces    
2025-02-12 14:58:43 ⚠️ HumanodeSession declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`    
2025-02-12 14:58:43 Running migration to v1 from StorageVersion(1)    
2025-02-12 14:58:43 Already at version 1, nothing to do    
2025-02-12 14:58:43 ⚠️ Ethereum declares internal migrations (which *might* execute). On-chain `StorageVersion(0)` vs current storage version `StorageVersion(0)`    
2025-02-12 14:58:43 ⚠️ BalancedCurrencySwapBridgesInitializer declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`    
2025-02-12 14:58:43 ⚠️ EvmBalancesErc20Support declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`    
2025-02-12 14:58:43 ⚠️ DummyPrecompilesCode declares internal migrations (which *might* execute). On-chain `StorageVersion(1)` vs current storage version `StorageVersion(1)`    
2025-02-12 14:58:48 💤 Idle (0 peers), best: #8 (0x7b62…0c9b), finalized #0 (0x2bb9…85ba), ⬇ 0 ⬆ 0    
2025-02-12 14:58:48 🎁 Prepared block for proposing at 9 (4543 ms) [hash: 0x317cbbf853b78e11caae9131cda11028f3e2967d433426a971fcb83e90182e7e; parent_hash: 0x7b62…0c9b; extrinsics (1): [0x0074…9c5d]]    
2025-02-12 14:58:48 🔖 Pre-sealed block for proposal at 9. Hash now 0x320c5ad1004ed5c7dddd41be444b5ccc09870b074248293273cf9a03b11aa835, previously 0x317cbbf853b78e11caae9131cda11028f3e2967d433426a971fcb83e90182e7e.    
2025-02-12 14:58:48 ✨ Imported #9 (0x320c…a835)
```

#### after upgrade

<img width="1440" alt="Screenshot 2025-02-12 at 14 59 01" src="https://github.com/user-attachments/assets/2fdb9d29-d8ab-4d4d-bfd9-e40584036578" />

