### PR TITLE
Implement own `RemovePallet` logic taking into account limit value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6801,6 +6801,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-support"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+]
+
+[[package]]
 name = "pallet-timestamp"
 version = "4.0.0-dev"
 source = "git+https://github.com/humanode-network/substrate?tag=locked/polkadot-v0.9.42-2024-09-12#56b16fefbd7a5ba07afd94cb37367d078da0ac52"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4147,6 +4147,7 @@ dependencies = [
  "pallet-pot",
  "pallet-session",
  "pallet-sudo",
+ "pallet-support",
  "pallet-timestamp",
  "pallet-token-claims",
  "pallet-transaction-payment",

--- a/crates/humanode-runtime/Cargo.toml
+++ b/crates/humanode-runtime/Cargo.toml
@@ -32,6 +32,7 @@ pallet-evm-system = { path = "../pallet-evm-system", default-features = false }
 pallet-humanode-offences = { path = "../pallet-humanode-offences", default-features = false }
 pallet-humanode-session = { path = "../pallet-humanode-session", default-features = false }
 pallet-pot = { path = "../pallet-pot", default-features = false }
+pallet-support = { path = "../pallet-support", default-features = false }
 pallet-token-claims = { path = "../pallet-token-claims", default-features = false }
 pallet-vesting = { path = "../pallet-vesting", default-features = false }
 precompile-bioauth = { path = "../precompile-bioauth", default-features = false }
@@ -190,6 +191,7 @@ std = [
   "pallet-pot/std",
   "pallet-session/std",
   "pallet-sudo/std",
+  "pallet-support/std",
   "pallet-timestamp/std",
   "pallet-token-claims/std",
   "pallet-transaction-payment-rpc-runtime-api/std",
@@ -260,6 +262,7 @@ try-runtime = [
   "pallet-pot/try-runtime",
   "pallet-session/try-runtime",
   "pallet-sudo/try-runtime",
+  "pallet-support/try-runtime",
   "pallet-timestamp/try-runtime",
   "pallet-token-claims/try-runtime",
   "pallet-transaction-payment/try-runtime",

--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -877,6 +877,8 @@ pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 parameter_types! {
     /// A static string representing already removed offences pallet name.
     pub const Offences: &'static str = "Offences";
+    /// Offences related keys limit to be removed.
+    pub const OffencesLimit: u32 = 10_000;
 }
 
 /// Executive: handles dispatch to the various modules.
@@ -887,7 +889,7 @@ pub type Executive = frame_executive::Executive<
     Runtime,
     AllPalletsWithSystem,
     (
-        frame_support::migrations::RemovePallet<Offences, RocksDbWeight>,
+        pallet_support::migrations::RemovePallet<Offences, OffencesLimit, RocksDbWeight>,
         pallet_bioauth::migrations::consumed_auth_ticket_nonces_cleaner::ConsumedAuthTicketNoncesCleaner<Runtime>,
     ),
 >;

--- a/crates/pallet-support/Cargo.toml
+++ b/crates/pallet-support/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pallet-support"
 version = "0.1.0"
 edition = "2021"
+publish = false
 
 [dependencies]
 frame-support = { workspace = true }

--- a/crates/pallet-support/Cargo.toml
+++ b/crates/pallet-support/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pallet-support"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+frame-support = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+  "frame-support/std",
+]
+try-runtime = ["frame-support/try-runtime"]

--- a/crates/pallet-support/src/lib.rs
+++ b/crates/pallet-support/src/lib.rs
@@ -1,3 +1,5 @@
 //! Pallets related support code for the runtime.
 
+#![cfg_attr(not(feature = "std"), no_std)]
+
 pub mod migrations;

--- a/crates/pallet-support/src/lib.rs
+++ b/crates/pallet-support/src/lib.rs
@@ -1,0 +1,3 @@
+//! Pallets related support code for the runtime.
+
+pub mod migrations;

--- a/crates/pallet-support/src/migrations.rs
+++ b/crates/pallet-support/src/migrations.rs
@@ -49,13 +49,13 @@ impl<P: Get<&'static str>, Limit: Get<Option<u32>>, DbWeight: Get<RuntimeDbWeigh
 
     #[cfg(feature = "try-runtime")]
     fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
-        // TODO: ...
+        // Do nothing.
         Ok(Vec::new())
     }
 
     #[cfg(feature = "try-runtime")]
     fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
-        // TODO: ...
+        // Do nothing.
         Ok(())
     }
 }

--- a/crates/pallet-support/src/migrations.rs
+++ b/crates/pallet-support/src/migrations.rs
@@ -9,7 +9,16 @@ use frame_support::{
     weights::RuntimeDbWeight,
 };
 
-/// TODO: ...
+/// `RemovePallet` is a utility struct used to remove all storage items associated with a specific
+/// pallet.
+///
+/// The implementation is based on [`frame_support::migrations::RemovePallet`], but doesn't focus
+/// just on removing all storage items per one runtime upgrade in one block. Additionally, it allows
+/// to use capabilities of `clear_prefix` with limit that can be used to partially delete a prefix
+/// storage in case it is too large to delete in one block.
+///
+/// We are going to upstream improved logic to <https://github.com/paritytech/polkadot-sdk> when
+/// we switched our substrate dependencies from archived substrate fork to polkadot-sdk fork.
 pub struct RemovePallet<
     P: Get<&'static str>,
     Limit: Get<Option<u32>>,

--- a/crates/pallet-support/src/migrations.rs
+++ b/crates/pallet-support/src/migrations.rs
@@ -1,0 +1,50 @@
+//! Migrations related support code.
+
+use frame_support::{
+    log,
+    pallet_prelude::*,
+    sp_io::{hashing::twox_128, storage::clear_prefix, KillStorageResult},
+    weights::RuntimeDbWeight,
+};
+
+/// TODO: ...
+pub struct RemovePallet<
+    P: Get<&'static str>,
+    Limit: Get<Option<u32>>,
+    DbWeight: Get<RuntimeDbWeight>,
+>(PhantomData<(P, Limit, DbWeight)>);
+
+impl<P: Get<&'static str>, Limit: Get<Option<u32>>, DbWeight: Get<RuntimeDbWeight>>
+    frame_support::traits::OnRuntimeUpgrade for RemovePallet<P, Limit, DbWeight>
+{
+    fn on_runtime_upgrade() -> frame_support::weights::Weight {
+        let pallet_name = P::get();
+        let hashed_prefix = twox_128(P::get().as_bytes());
+
+        let keys_removed: u64 = match clear_prefix(&hashed_prefix, Limit::get()) {
+            KillStorageResult::AllRemoved(value) => {
+                log::info!("{pallet_name}: Removed all {value} keys 🧹");
+                value
+            }
+            KillStorageResult::SomeRemaining(value) => {
+                log::info!("{pallet_name}: Removed {value} keys, some of them still remain 🧹");
+                value
+            }
+        }
+        .into();
+
+        DbWeight::get().reads_writes(keys_removed, keys_removed)
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
+        // TODO: ...
+        Ok(Vec::new())
+    }
+
+    #[cfg(feature = "try-runtime")]
+    fn post_upgrade(_state: Vec<u8>) -> Result<(), &'static str> {
+        // TODO: ...
+        Ok(())
+    }
+}

--- a/crates/pallet-support/src/migrations.rs
+++ b/crates/pallet-support/src/migrations.rs
@@ -1,5 +1,7 @@
 //! Migrations related support code.
 
+#[cfg(feature = "try-runtime")]
+use frame_support::sp_std::vec::Vec;
 use frame_support::{
     log,
     pallet_prelude::*,

--- a/utils/checks/snapshots/features.yaml
+++ b/utils/checks/snapshots/features.yaml
@@ -2232,6 +2232,10 @@
 - name: pallet-sudo 4.0.0-dev
   features:
     - std
+- name: pallet-support 0.1.0
+  features:
+    - default
+    - std
 - name: pallet-timestamp 4.0.0-dev
   features:
     - default


### PR DESCRIPTION
Thanks @quasiyoke by noting that consumed weight is much higher than a total weight at https://github.com/humanode-network/humanode/pull/1433#issuecomment-2657144267. The root cause comes from #1434.

Proposing to add `RemovePallet` based on [`frame_support::migrations::RemovePallet`], but doesn't focus just on removing all storage items per one runtime upgrade in one block. Additionally, it allows to use capabilities of `clear_prefix` with limit that can be used to partially delete a prefix storage in case it is too large to delete in one block.

### `try-runtime` over current master with offences removal

```
2025-02-18 13:04:47.930  INFO main try-runtime::cli: TryRuntime_on_runtime_upgrade executed without errors. Consumed weight = (**10102150000000** ps, 0 byte), total weight = (**2000000000000** ps, 18446744073709551615 byte) (**505.11 %**, 0.00 %).    
Test succeeded
```

### `try-runtime` over proposed code with offences removal

```
2025-02-18 16:01:30.514  INFO main try-runtime::cli: TryRuntime_on_runtime_upgrade executed without errors. Consumed weight = (**1250375000000** ps, 0 byte), total weight = (**2000000000000** ps, 18446744073709551615 byte) (**62.52 %**, 0.00 %).    
Test succeeded
```