### PR TITLE
Revert "Clear all storage items associated with removed Offences pallet at runtime level (#1434)"

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -874,11 +874,6 @@ pub type UncheckedExtrinsic =
 /// The payload being signed in transactions.
 pub type SignedPayload = generic::SignedPayload<RuntimeCall, SignedExtra>;
 
-parameter_types! {
-    /// A static string representing already removed offences pallet name.
-    pub const Offences: &'static str = "Offences";
-}
-
 /// Executive: handles dispatch to the various modules.
 pub type Executive = frame_executive::Executive<
     Runtime,
@@ -887,7 +882,6 @@ pub type Executive = frame_executive::Executive<
     Runtime,
     AllPalletsWithSystem,
     (
-        frame_support::migrations::RemovePallet<Offences, RocksDbWeight>,
         pallet_bioauth::migrations::consumed_auth_ticket_nonces_cleaner::ConsumedAuthTicketNoncesCleaner<Runtime>,
     ),
 >;


### PR DESCRIPTION
My bad, missed that consumed weight is much higher than total weight during `try-runtime` run over mainnet (over `500%`).

After revert its about `0.02%`