### PR TITLE
Adapt docker build flow to latest rust:bookwarm release containing rustup update to version 1.28.0

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -51,7 +51,7 @@ docker run \
   --workdir /build \
   --user "$(id -u):$(id -g)" \
   "$BUILDER_CONTAINER_TAG" \
-  cargo build --release
+  rustup toolchain install && cargo build --release
 
 # Prepare artifacts.
 TMP_ARTIFACTS_DIR="$(mktemp -d)"


### PR DESCRIPTION
`rustup will no longer automatically install the active toolchain if it is not installed`

- https://github.com/rust-lang/docker-rust/pull/230
- https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md