### PR TITLE
Temporarily ignore RUSTSEC-2025-0009 for internal substrate deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -981,12 +981,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -4185,9 +4186,9 @@ checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
 name = "jobserver"
-version = "0.1.28"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab46a6e9526ddef3ae7f787c06f0f2600639ba80ea3eade3d8e670a2230f51d6"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
@@ -7607,16 +7608,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom 0.2.15",
  "libc",
- "spin 0.9.8",
  "untrusted 0.9.0",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7859,7 +7860,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
 dependencies = [
  "log",
- "ring 0.17.7",
+ "ring 0.17.13",
  "rustls-webpki",
  "sct",
 ]
@@ -7891,7 +7892,7 @@ version = "0.101.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.13",
  "untrusted 0.9.0",
 ]
 
@@ -9024,7 +9025,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.13",
  "untrusted 0.9.0",
 ]
 
@@ -9418,7 +9419,7 @@ dependencies = [
  "chacha20poly1305",
  "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
- "ring 0.17.7",
+ "ring 0.17.13",
  "rustc_version",
  "sha2 0.10.8",
  "subtle",
@@ -11894,7 +11895,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed63aea5ce73d0ff405984102c42de94fc55a6b75765d621c65262469b3c9b53"
 dependencies = [
- "ring 0.17.7",
+ "ring 0.17.13",
  "untrusted 0.9.0",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -28,6 +28,8 @@ ignore = [
   "RUSTSEC-2024-0363",
   # TODO(#1361): update the idna internal dependency to 1.0.0+
   "RUSTSEC-2024-0421",
+  # TODO(#1478): update the ring internal dependency to 0.17.12+
+  "RUSTSEC-2025-0009",
 ]
 
 [licenses]

--- a/utils/checks/snapshots/features.yaml
+++ b/utils/checks/snapshots/features.yaml
@@ -302,9 +302,8 @@
 - name: cargo_metadata 0.18.1
   features:
     - default
-- name: cc 1.0.83
+- name: cc 1.2.16
   features:
-    - jobserver
     - parallel
 - name: cexpr 0.6.0
   features: []
@@ -1370,7 +1369,7 @@
     - use_std
 - name: itoa 1.0.10
   features: []
-- name: jobserver 0.1.28
+- name: jobserver 0.1.32
   features: []
 - name: js-sys 0.3.68
   features: []
@@ -2459,7 +2458,7 @@
     - default
     - dev_urandom_fallback
     - once_cell
-- name: ring 0.17.7
+- name: ring 0.17.13
   features:
     - alloc
     - default


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2025-0009.html

- updated ring version for our own deps from vulnerable `v0.17.7` to fixed `v0.17.13`
- temporarily ignore `v0.16.20` that is a part of `substrate` deps part of `rustls 0.20.9` part of libp2p internal deps mostly. Of course, we would bump it as soon we bump substrate

Btw, the vulnerability description looks like that it shouldn't affect our code as `Protocols like TLS and SSH are not affected by this because those protocols break large amounts of data into small chunks`.