### PR TITLE
Remove already applied `pallet_multisig::migrations::v1::MigrateToV1` at `humanode-runtime` migrations scope

### DIFF
--- a/crates/humanode-runtime/src/lib.rs
+++ b/crates/humanode-runtime/src/lib.rs
@@ -889,7 +889,6 @@ pub type Executive = frame_executive::Executive<
             ConstU32<1000>,
             frontier_precompiles::FrontierPrecompilesAddresses<Runtime>,
         >,
-        pallet_multisig::migrations::v1::MigrateToV1<Runtime>,
         storage_version_initializer::StorageVersionInitializer<Balances, Runtime>,
     ),
 >;


### PR DESCRIPTION
`try-runtime` checks at ci throw error now `called Result::unwrap() on an Err value: Other("this migration can be deleted")` after executed runtime upgrade at mainnet to 127 due to https://github.com/humanode-network/substrate/blob/8afcafd721d31939e4dee7b779f152ab9eb1c8be/frame/multisig/src/migrations.rs#L49

#1498 has faced this error. So, probably, we should remove it now. 

Btw, I don't think that `pallet_multisig::migrations` should throw error for this logic at `pre_upgrade` implementation.