### PR TITLE
Fungible conformance Inspect and Mutate test for `pallet-evm-balances`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6112,6 +6112,7 @@ dependencies = [
  "pallet-evm-system",
  "pallet-timestamp",
  "parity-scale-codec",
+ "paste",
  "scale-info",
  "sp-core",
  "sp-io",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6108,6 +6108,7 @@ dependencies = [
  "fp-evm",
  "frame-support",
  "frame-system",
+ "hex-literal",
  "pallet-evm",
  "pallet-evm-system",
  "pallet-timestamp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ num-traits = { version = "0.2", default-features = false }
 num_enum = { version = "0.7", default-features = false }
 numtoa = { version = "0.2", default-features = false }
 once_cell = { version = "1", default-features = false }
+paste = { version = "1.0", default-features = false }
 proc-macro2 = { version = "1", default-features = false }
 qr2term = { version = "0.3", default-features = false }
 quote = { version = "1.0", default-features = false }

--- a/crates/pallet-evm-balances/Cargo.toml
+++ b/crates/pallet-evm-balances/Cargo.toml
@@ -16,6 +16,7 @@ sp-std = { workspace = true }
 pallet-evm-system = { path = "../pallet-evm-system", features = ["default"] }
 
 fp-evm = { workspace = true }
+hex-literal = { workspace = true }
 pallet-evm = { workspace = true }
 pallet-timestamp = { workspace = true }
 paste = { workspace = true }

--- a/crates/pallet-evm-balances/Cargo.toml
+++ b/crates/pallet-evm-balances/Cargo.toml
@@ -18,6 +18,7 @@ pallet-evm-system = { path = "../pallet-evm-system", features = ["default"] }
 fp-evm = { workspace = true }
 pallet-evm = { workspace = true }
 pallet-timestamp = { workspace = true }
+paste = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 

--- a/crates/pallet-evm-balances/src/mock.rs
+++ b/crates/pallet-evm-balances/src/mock.rs
@@ -19,24 +19,20 @@ use crate::{self as pallet_evm_balances, *};
 pub(crate) const INIT_BALANCE: u64 = 10_000_000_000_000_000;
 
 /// Alice account.
-pub fn alice() -> u64 {
-    5234
-}
+pub const ALICE: u64 = 0x5234;
 
 /// Alice H160 account.
-pub fn alice_h160() -> H160 {
-    H160::from_low_u64_be(alice())
-}
+pub const ALICE_H160: H160 = H160(hex_literal::hex!(
+    "0000000000000000000000000000000000005234"
+));
 
 /// Bob account.
-pub fn bob() -> u64 {
-    4325
-}
+pub const BOB: u64 = 0x4235;
 
 /// Bob H160 account.
-pub fn bob_h160() -> H160 {
-    H160::from_low_u64_be(bob())
-}
+pub const BOB_H160: H160 = H160(hex_literal::hex!(
+    "0000000000000000000000000000000000004235"
+));
 
 /// H160 into u64 address mapper.
 pub struct H160IntoU64;
@@ -188,8 +184,8 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
                     nonce: Default::default(),
                     storage: Default::default(),
                 };
-                map.insert(alice_h160(), init_genesis_account.clone());
-                map.insert(bob_h160(), init_genesis_account);
+                map.insert(ALICE_H160, init_genesis_account.clone());
+                map.insert(BOB_H160, init_genesis_account);
                 map
             },
         },

--- a/crates/pallet-evm-balances/src/tests/currency.rs
+++ b/crates/pallet-evm-balances/src/tests/currency.rs
@@ -1,9 +1,7 @@
 //! Tests regarding the functionality of the `Currency` trait set implementations.
 
 use frame_support::{assert_noop, assert_ok, traits::Currency};
-use sp_core::H160;
 use sp_runtime::TokenError;
-use sp_std::str::FromStr;
 
 use crate::{mock::*, tests::assert_total_issuance_invariant, *};
 
@@ -353,7 +351,7 @@ fn deposit_into_existing_fails_overflow() {
 #[test]
 fn deposit_into_existing_fails_dead_account() {
     new_test_ext().execute_with_ext(|_| {
-        let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+        let charlie = 3;
 
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&charlie), 0);
@@ -372,7 +370,7 @@ fn deposit_into_existing_fails_dead_account() {
 fn deposit_creating_works() {
     new_test_ext().execute_with_ext(|_| {
         // Prepare test preconditions.
-        let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+        let charlie = 3;
         let deposited_amount = 10;
         assert!(!EvmSystem::account_exists(&charlie));
 
@@ -517,7 +515,7 @@ fn withdraw_fails_expendability() {
 fn make_free_balance_be_works() {
     new_test_ext().execute_with_ext(|_| {
         // Prepare test preconditions.
-        let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+        let charlie = 3;
         let made_free_balance = 100;
 
         // Check test preconditions.
@@ -565,8 +563,8 @@ fn evm_system_account_should_be_reaped() {
 fn transferring_too_high_value_should_not_panic() {
     new_test_ext().execute_with_ext(|_| {
         // Prepare test preconditions.
-        let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
-        let eve = H160::from_str("1000000000000000000000000000000000000004").unwrap();
+        let charlie = 3;
+        let eve = 4;
         EvmBalances::make_free_balance_be(&charlie, u64::MAX);
         EvmBalances::make_free_balance_be(&eve, 1);
 

--- a/crates/pallet-evm-balances/src/tests/currency.rs
+++ b/crates/pallet-evm-balances/src/tests/currency.rs
@@ -17,7 +17,7 @@ fn total_issuance_works() {
 fn total_balance_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check the total balance value.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
     });
 }
 
@@ -25,7 +25,7 @@ fn total_balance_works() {
 fn free_balance_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check the free balance value.
-        assert_eq!(EvmBalances::free_balance(alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::free_balance(ALICE), INIT_BALANCE);
     });
 }
 
@@ -33,13 +33,13 @@ fn free_balance_works() {
 fn can_slash_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check possible slashing if slashing value is less than current balance.
-        assert!(EvmBalances::can_slash(&alice(), 100));
+        assert!(EvmBalances::can_slash(&ALICE, 100));
 
         // Check possible slashing if slashing value is equal to current balance.
-        assert!(EvmBalances::can_slash(&alice(), INIT_BALANCE));
+        assert!(EvmBalances::can_slash(&ALICE, INIT_BALANCE));
 
         // Check slashing restriction if slashing value that is greater than current balance.
-        assert!(!EvmBalances::can_slash(&alice(), INIT_BALANCE + 1));
+        assert!(!EvmBalances::can_slash(&ALICE, INIT_BALANCE + 1));
     });
 }
 
@@ -119,7 +119,7 @@ fn issue_works() {
 fn transfer_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let transferred_amount = 100;
 
@@ -128,24 +128,24 @@ fn transfer_works() {
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::transfer(
-            &alice(),
-            &bob(),
+            &ALICE,
+            &BOB,
             transferred_amount,
             ExistenceRequirement::KeepAlive
         ));
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - transferred_amount
         );
         assert_eq!(
-            EvmBalances::total_balance(&bob()),
+            EvmBalances::total_balance(&BOB),
             INIT_BALANCE + transferred_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Transfer {
-            from: alice(),
-            to: bob(),
+            from: ALICE,
+            to: BOB,
             amount: transferred_amount,
         }));
 
@@ -157,7 +157,7 @@ fn transfer_works() {
 fn transfer_works_full_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let transferred_amount = INIT_BALANCE;
 
@@ -166,29 +166,29 @@ fn transfer_works_full_balance() {
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::transfer(
-            &alice(),
-            &bob(),
+            &ALICE,
+            &BOB,
             transferred_amount,
             ExistenceRequirement::AllowDeath
         ));
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - transferred_amount
         );
         assert_eq!(
-            EvmBalances::total_balance(&bob()),
+            EvmBalances::total_balance(&BOB),
             INIT_BALANCE + transferred_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Transfer {
-            from: alice(),
-            to: bob(),
+            from: ALICE,
+            to: BOB,
             amount: transferred_amount,
         }));
-        assert!(!EvmSystem::account_exists(&alice()));
+        assert!(!EvmSystem::account_exists(&ALICE));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: alice() },
+            pallet_evm_system::Event::KilledAccount { account: ALICE },
         ));
 
         assert_total_issuance_invariant();
@@ -199,7 +199,7 @@ fn transfer_works_full_balance() {
 fn transfer_fails_funds_unavailable() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let transferred_amount = INIT_BALANCE + 1;
 
@@ -209,8 +209,8 @@ fn transfer_fails_funds_unavailable() {
         // Invoke the function under test.
         assert_noop!(
             EvmBalances::transfer(
-                &alice(),
-                &bob(),
+                &ALICE,
+                &BOB,
                 transferred_amount,
                 ExistenceRequirement::KeepAlive
             ),
@@ -223,7 +223,7 @@ fn transfer_fails_funds_unavailable() {
 fn transfer_fails_not_expendable() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let transferred_amount = INIT_BALANCE;
 
@@ -233,8 +233,8 @@ fn transfer_fails_not_expendable() {
         // Invoke the function under test.
         assert_noop!(
             EvmBalances::transfer(
-                &alice(),
-                &bob(),
+                &ALICE,
+                &BOB,
                 transferred_amount,
                 ExistenceRequirement::KeepAlive
             ),
@@ -247,7 +247,7 @@ fn transfer_fails_not_expendable() {
 fn slash_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let slashed_amount = 1000;
 
@@ -255,15 +255,15 @@ fn slash_works() {
         System::set_block_number(1);
 
         // Invoke the function under test.
-        assert!(EvmBalances::slash(&alice(), slashed_amount).1.is_zero());
+        assert!(EvmBalances::slash(&ALICE, slashed_amount).1.is_zero());
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - slashed_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Slashed {
-            who: alice(),
+            who: ALICE,
             amount: slashed_amount,
         }));
 
@@ -275,7 +275,7 @@ fn slash_works() {
 fn slash_works_full_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let slashed_amount = INIT_BALANCE;
 
@@ -283,20 +283,20 @@ fn slash_works_full_balance() {
         System::set_block_number(1);
 
         // Invoke the function under test.
-        assert!(EvmBalances::slash(&alice(), slashed_amount).1.is_zero());
+        assert!(EvmBalances::slash(&ALICE, slashed_amount).1.is_zero());
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - slashed_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Slashed {
-            who: alice(),
+            who: ALICE,
             amount: slashed_amount,
         }));
-        assert!(!EvmSystem::account_exists(&alice()));
+        assert!(!EvmSystem::account_exists(&ALICE));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: alice() },
+            pallet_evm_system::Event::KilledAccount { account: ALICE },
         ));
 
         assert_total_issuance_invariant();
@@ -307,7 +307,7 @@ fn slash_works_full_balance() {
 fn deposit_into_existing_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let deposited_amount = 10;
 
@@ -315,16 +315,16 @@ fn deposit_into_existing_works() {
         System::set_block_number(1);
 
         // Invoke the function under test.
-        let imbalance = EvmBalances::deposit_into_existing(&alice(), deposited_amount).unwrap();
+        let imbalance = EvmBalances::deposit_into_existing(&ALICE, deposited_amount).unwrap();
         drop(imbalance);
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE + deposited_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Deposit {
-            who: alice(),
+            who: ALICE,
             amount: deposited_amount,
         }));
 
@@ -336,13 +336,13 @@ fn deposit_into_existing_works() {
 fn deposit_into_existing_fails_overflow() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let deposited_amount = u64::MAX;
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::deposit_into_existing(&alice(), deposited_amount),
+            EvmBalances::deposit_into_existing(&ALICE, deposited_amount),
             ArithmeticError::Overflow
         );
     });
@@ -399,7 +399,7 @@ fn deposit_creating_works() {
 fn withdraw_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let withdrawed_amount = 1000;
 
@@ -408,7 +408,7 @@ fn withdraw_works() {
 
         // Invoke the function under test.
         let imbalance = EvmBalances::withdraw(
-            &alice(),
+            &ALICE,
             withdrawed_amount,
             WithdrawReasons::FEE,
             ExistenceRequirement::KeepAlive,
@@ -418,11 +418,11 @@ fn withdraw_works() {
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - withdrawed_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Withdraw {
-            who: alice(),
+            who: ALICE,
             amount: withdrawed_amount,
         }));
 
@@ -434,7 +434,7 @@ fn withdraw_works() {
 fn withdraw_works_full_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let withdrawed_amount = INIT_BALANCE;
 
@@ -443,7 +443,7 @@ fn withdraw_works_full_balance() {
 
         // Invoke the function under test.
         let imbalance = EvmBalances::withdraw(
-            &alice(),
+            &ALICE,
             withdrawed_amount,
             WithdrawReasons::FEE,
             ExistenceRequirement::AllowDeath,
@@ -453,16 +453,16 @@ fn withdraw_works_full_balance() {
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - withdrawed_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Withdraw {
-            who: alice(),
+            who: ALICE,
             amount: withdrawed_amount,
         }));
-        assert!(!EvmSystem::account_exists(&alice()));
+        assert!(!EvmSystem::account_exists(&ALICE));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: alice() },
+            pallet_evm_system::Event::KilledAccount { account: ALICE },
         ));
 
         assert_total_issuance_invariant();
@@ -473,14 +473,14 @@ fn withdraw_works_full_balance() {
 fn withdraw_fails_insufficient_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let withdrawed_amount = INIT_BALANCE + 1;
 
         // Invoke the function under test.
         assert_noop!(
             EvmBalances::withdraw(
-                &alice(),
+                &ALICE,
                 withdrawed_amount,
                 WithdrawReasons::TRANSFER,
                 ExistenceRequirement::AllowDeath
@@ -494,14 +494,14 @@ fn withdraw_fails_insufficient_balance() {
 fn withdraw_fails_expendability() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let withdrawed_amount = INIT_BALANCE;
 
         // Invoke the function under test.
         assert_noop!(
             EvmBalances::withdraw(
-                &alice(),
+                &ALICE,
                 withdrawed_amount,
                 WithdrawReasons::TRANSFER,
                 ExistenceRequirement::KeepAlive
@@ -535,24 +535,24 @@ fn make_free_balance_be_works() {
 fn evm_system_account_should_be_reaped() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert!(EvmSystem::account_exists(&bob()));
+        assert!(EvmSystem::account_exists(&BOB));
 
         // Set block number to enable events.
         System::set_block_number(1);
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::transfer(
-            &bob(),
-            &alice(),
+            &BOB,
+            &ALICE,
             INIT_BALANCE,
             ExistenceRequirement::AllowDeath
         ));
 
         // Assert state changes.
-        assert_eq!(EvmBalances::free_balance(bob()), 0);
-        assert!(!EvmSystem::account_exists(&bob()));
+        assert_eq!(EvmBalances::free_balance(BOB), 0);
+        assert!(!EvmSystem::account_exists(&BOB));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: bob() },
+            pallet_evm_system::Event::KilledAccount { account: BOB },
         ));
 
         assert_total_issuance_invariant();

--- a/crates/pallet-evm-balances/src/tests/fungible.rs
+++ b/crates/pallet-evm-balances/src/tests/fungible.rs
@@ -7,9 +7,7 @@ use frame_support::{
         tokens::Precision,
     },
 };
-use sp_core::H160;
 use sp_runtime::TokenError;
-use sp_std::str::FromStr;
 
 use crate::{mock::*, tests::assert_total_issuance_invariant, *};
 
@@ -799,8 +797,8 @@ fn transfer_fails_not_expendable() {
 fn transfer_fails_underflow() {
     new_test_ext().execute_with_ext(|_| {
         // Prepare test preconditions.
-        let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
-        let eve = H160::from_str("1000000000000000000000000000000000000004").unwrap();
+        let charlie = 3;
+        let eve = 4;
         EvmBalances::set_balance(&charlie, u64::MAX);
         EvmBalances::set_balance(&eve, 1);
 
@@ -906,7 +904,7 @@ fn deposit_flow_works() {
 #[test]
 fn deposit_works_new_account() {
     new_test_ext().execute_with_ext(|_| {
-        let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+        let charlie = 3;
 
         // Check test preconditions.
         assert_eq!(EvmBalances::total_balance(&charlie), 0);

--- a/crates/pallet-evm-balances/src/tests/fungible.rs
+++ b/crates/pallet-evm-balances/src/tests/fungible.rs
@@ -39,7 +39,7 @@ fn minimum_balance_works() {
 fn total_balance_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check the total balance value.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
     });
 }
 
@@ -47,7 +47,7 @@ fn total_balance_works() {
 fn balance_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check the balance value.
-        assert_eq!(EvmBalances::balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::balance(&ALICE), INIT_BALANCE);
     });
 }
 
@@ -55,32 +55,32 @@ fn balance_works() {
 fn reducable_balance_works() {
     new_test_ext().execute_with_ext(|_| {
         assert_eq!(
-            EvmBalances::reducible_balance(&alice(), Preservation::Expendable, Fortitude::Polite),
+            EvmBalances::reducible_balance(&ALICE, Preservation::Expendable, Fortitude::Polite),
             INIT_BALANCE
         );
 
         assert_eq!(
-            EvmBalances::reducible_balance(&alice(), Preservation::Expendable, Fortitude::Force),
+            EvmBalances::reducible_balance(&ALICE, Preservation::Expendable, Fortitude::Force),
             INIT_BALANCE
         );
 
         assert_eq!(
-            EvmBalances::reducible_balance(&alice(), Preservation::Preserve, Fortitude::Polite),
+            EvmBalances::reducible_balance(&ALICE, Preservation::Preserve, Fortitude::Polite),
             INIT_BALANCE - 1
         );
 
         assert_eq!(
-            EvmBalances::reducible_balance(&alice(), Preservation::Preserve, Fortitude::Force),
+            EvmBalances::reducible_balance(&ALICE, Preservation::Preserve, Fortitude::Force),
             INIT_BALANCE - 1
         );
 
         assert_eq!(
-            EvmBalances::reducible_balance(&alice(), Preservation::Protect, Fortitude::Polite),
+            EvmBalances::reducible_balance(&ALICE, Preservation::Protect, Fortitude::Polite),
             INIT_BALANCE - 1
         );
 
         assert_eq!(
-            EvmBalances::reducible_balance(&alice(), Preservation::Protect, Fortitude::Force),
+            EvmBalances::reducible_balance(&ALICE, Preservation::Protect, Fortitude::Force),
             INIT_BALANCE - 1
         );
     });
@@ -90,7 +90,7 @@ fn reducable_balance_works() {
 fn can_deposit_works_success() {
     new_test_ext().execute_with_ext(|_| {
         assert_eq!(
-            EvmBalances::can_deposit(&alice(), 10, Provenance::Minted),
+            EvmBalances::can_deposit(&ALICE, 10, Provenance::Minted),
             DepositConsequence::Success
         );
     });
@@ -100,7 +100,7 @@ fn can_deposit_works_success() {
 fn can_deposit_works_overflow() {
     new_test_ext().execute_with_ext(|_| {
         assert_eq!(
-            EvmBalances::can_deposit(&alice(), u64::MAX, Provenance::Minted),
+            EvmBalances::can_deposit(&ALICE, u64::MAX, Provenance::Minted),
             DepositConsequence::Overflow
         );
     });
@@ -110,7 +110,7 @@ fn can_deposit_works_overflow() {
 fn can_withdraw_works_success() {
     new_test_ext().execute_with_ext(|_| {
         assert_eq!(
-            EvmBalances::can_withdraw(&alice(), 10),
+            EvmBalances::can_withdraw(&ALICE, 10),
             WithdrawConsequence::Success
         );
     });
@@ -120,7 +120,7 @@ fn can_withdraw_works_success() {
 fn can_withdraw_works_underflow() {
     new_test_ext().execute_with_ext(|_| {
         assert_eq!(
-            EvmBalances::can_withdraw(&alice(), u64::MAX),
+            EvmBalances::can_withdraw(&ALICE, u64::MAX),
             WithdrawConsequence::Underflow
         );
     });
@@ -130,7 +130,7 @@ fn can_withdraw_works_underflow() {
 fn can_withdraw_works_balance_low() {
     new_test_ext().execute_with_ext(|_| {
         assert_eq!(
-            EvmBalances::can_withdraw(&alice(), INIT_BALANCE + 1),
+            EvmBalances::can_withdraw(&ALICE, INIT_BALANCE + 1),
             WithdrawConsequence::BalanceLow
         );
     });
@@ -140,7 +140,7 @@ fn can_withdraw_works_balance_low() {
 fn can_withdraw_works_reduced_to_zero() {
     new_test_ext().execute_with_ext(|_| {
         assert_eq!(
-            EvmBalances::can_withdraw(&alice(), INIT_BALANCE),
+            EvmBalances::can_withdraw(&ALICE, INIT_BALANCE),
             WithdrawConsequence::ReducedToZero(0)
         );
     });
@@ -150,18 +150,15 @@ fn can_withdraw_works_reduced_to_zero() {
 fn write_balance_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let write_balance = 10;
 
         // Invoke the function under test.
-        assert_eq!(
-            EvmBalances::write_balance(&alice(), write_balance),
-            Ok(None)
-        );
+        assert_eq!(EvmBalances::write_balance(&ALICE, write_balance), Ok(None));
 
         // Assert state changes.
-        assert_eq!(EvmBalances::total_balance(&alice()), write_balance);
+        assert_eq!(EvmBalances::total_balance(&ALICE), write_balance);
     });
 }
 
@@ -185,13 +182,13 @@ fn set_total_issuance_works() {
 fn decrease_balance_works_exact_expendable() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let decreased_balance = 100;
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::decrease_balance(
-            &alice(),
+            &ALICE,
             decreased_balance,
             Precision::Exact,
             Preservation::Expendable,
@@ -200,7 +197,7 @@ fn decrease_balance_works_exact_expendable() {
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - decreased_balance
         );
     });
@@ -210,13 +207,13 @@ fn decrease_balance_works_exact_expendable() {
 fn decrease_balance_works_best_effort_preserve() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let decreased_balance = INIT_BALANCE + 1;
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::decrease_balance(
-            &alice(),
+            &ALICE,
             decreased_balance,
             Precision::BestEffort,
             Preservation::Preserve,
@@ -224,7 +221,7 @@ fn decrease_balance_works_best_effort_preserve() {
         ));
 
         // Assert state changes.
-        assert_eq!(EvmBalances::total_balance(&alice()), 1);
+        assert_eq!(EvmBalances::total_balance(&ALICE), 1);
     });
 }
 
@@ -232,7 +229,7 @@ fn decrease_balance_works_best_effort_preserve() {
 fn decrease_balance_works_full_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         // Set block number to enable events.
         System::set_block_number(1);
@@ -241,7 +238,7 @@ fn decrease_balance_works_full_balance() {
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::decrease_balance(
-            &alice(),
+            &ALICE,
             decreased_balance,
             Precision::Exact,
             Preservation::Expendable,
@@ -249,10 +246,10 @@ fn decrease_balance_works_full_balance() {
         ));
 
         // Assert state changes.
-        assert_eq!(EvmBalances::total_balance(&alice()), 0);
-        assert!(!EvmSystem::account_exists(&alice()));
+        assert_eq!(EvmBalances::total_balance(&ALICE), 0);
+        assert!(!EvmSystem::account_exists(&ALICE));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: alice() },
+            pallet_evm_system::Event::KilledAccount { account: ALICE },
         ));
     });
 }
@@ -261,14 +258,14 @@ fn decrease_balance_works_full_balance() {
 fn decrease_balance_fails_funds_unavailable() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let decreased_balance = INIT_BALANCE + 1;
 
         // Invoke the function under test.
         assert_noop!(
             EvmBalances::decrease_balance(
-                &alice(),
+                &ALICE,
                 decreased_balance,
                 Precision::Exact,
                 Preservation::Preserve,
@@ -283,20 +280,20 @@ fn decrease_balance_fails_funds_unavailable() {
 fn increase_balance_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let increased_balance = 100;
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::increase_balance(
-            &alice(),
+            &ALICE,
             increased_balance,
             Precision::Exact,
         ));
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE + increased_balance
         );
     });
@@ -306,19 +303,19 @@ fn increase_balance_works() {
 fn increase_balance_works_best_effort() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let increased_balance = u64::MAX;
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::increase_balance(
-            &alice(),
+            &ALICE,
             increased_balance,
             Precision::BestEffort,
         ));
 
         // Assert state changes.
-        assert_eq!(EvmBalances::total_balance(&alice()), u64::MAX);
+        assert_eq!(EvmBalances::total_balance(&ALICE), u64::MAX);
     });
 }
 
@@ -326,13 +323,13 @@ fn increase_balance_works_best_effort() {
 fn increase_balance_fails_overflow() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let increased_balance = u64::MAX;
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::increase_balance(&alice(), increased_balance, Precision::Exact),
+            EvmBalances::increase_balance(&ALICE, increased_balance, Precision::Exact),
             ArithmeticError::Overflow
         );
     });
@@ -362,7 +359,7 @@ fn deactivate_reactivate_works() {
 fn mint_into_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         // Set block number to enable events.
@@ -371,11 +368,11 @@ fn mint_into_works() {
         let minted_balance = 10;
 
         // Invoke the function under test.
-        assert_ok!(EvmBalances::mint_into(&alice(), minted_balance));
+        assert_ok!(EvmBalances::mint_into(&ALICE, minted_balance));
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE + minted_balance
         );
         assert_eq!(
@@ -383,7 +380,7 @@ fn mint_into_works() {
             2 * INIT_BALANCE + minted_balance
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Minted {
-            who: alice(),
+            who: ALICE,
             amount: minted_balance,
         }));
 
@@ -395,13 +392,13 @@ fn mint_into_works() {
 fn mint_into_fails_overflow() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let minted_balance = u64::MAX;
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::mint_into(&alice(), minted_balance),
+            EvmBalances::mint_into(&ALICE, minted_balance),
             ArithmeticError::Overflow
         );
     });
@@ -411,7 +408,7 @@ fn mint_into_fails_overflow() {
 fn burn_from_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         // Set block number to enable events.
@@ -421,7 +418,7 @@ fn burn_from_works() {
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::burn_from(
-            &alice(),
+            &ALICE,
             burned_balance,
             Precision::Exact,
             Fortitude::Polite
@@ -429,7 +426,7 @@ fn burn_from_works() {
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - burned_balance
         );
         assert_eq!(
@@ -437,7 +434,7 @@ fn burn_from_works() {
             2 * INIT_BALANCE - burned_balance
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Burned {
-            who: alice(),
+            who: ALICE,
             amount: burned_balance,
         }));
 
@@ -449,7 +446,7 @@ fn burn_from_works() {
 fn burn_from_works_best_effort() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         // Set block number to enable events.
@@ -459,22 +456,22 @@ fn burn_from_works_best_effort() {
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::burn_from(
-            &alice(),
+            &ALICE,
             burned_balance,
             Precision::BestEffort,
             Fortitude::Polite
         ));
 
         // Assert state changes.
-        assert_eq!(EvmBalances::total_balance(&alice()), 0);
+        assert_eq!(EvmBalances::total_balance(&ALICE), 0);
         assert_eq!(EvmBalances::total_issuance(), INIT_BALANCE);
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Burned {
-            who: alice(),
+            who: ALICE,
             amount: INIT_BALANCE,
         }));
-        assert!(!EvmSystem::account_exists(&alice()));
+        assert!(!EvmSystem::account_exists(&ALICE));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: alice() },
+            pallet_evm_system::Event::KilledAccount { account: ALICE },
         ));
 
         assert_total_issuance_invariant();
@@ -485,7 +482,7 @@ fn burn_from_works_best_effort() {
 fn burn_from_works_exact_full_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         // Set block number to enable events.
@@ -495,22 +492,22 @@ fn burn_from_works_exact_full_balance() {
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::burn_from(
-            &alice(),
+            &ALICE,
             burned_balance,
             Precision::Exact,
             Fortitude::Polite
         ));
 
         // Assert state changes.
-        assert_eq!(EvmBalances::total_balance(&alice()), 0);
+        assert_eq!(EvmBalances::total_balance(&ALICE), 0);
         assert_eq!(EvmBalances::total_issuance(), INIT_BALANCE);
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Burned {
-            who: alice(),
+            who: ALICE,
             amount: INIT_BALANCE,
         }));
-        assert!(!EvmSystem::account_exists(&alice()));
+        assert!(!EvmSystem::account_exists(&ALICE));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: alice() },
+            pallet_evm_system::Event::KilledAccount { account: ALICE },
         ));
 
         assert_total_issuance_invariant();
@@ -521,7 +518,7 @@ fn burn_from_works_exact_full_balance() {
 fn burn_from_fails_funds_unavailable() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         // Set block number to enable events.
@@ -531,12 +528,7 @@ fn burn_from_fails_funds_unavailable() {
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::burn_from(
-                &alice(),
-                burned_balance,
-                Precision::Exact,
-                Fortitude::Polite
-            ),
+            EvmBalances::burn_from(&ALICE, burned_balance, Precision::Exact, Fortitude::Polite),
             TokenError::FundsUnavailable
         );
     });
@@ -546,7 +538,7 @@ fn burn_from_fails_funds_unavailable() {
 fn shelve_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         // Set block number to enable events.
@@ -555,11 +547,11 @@ fn shelve_works() {
         let shelved_balance = 10;
 
         // Invoke the function under test.
-        assert_ok!(EvmBalances::shelve(&alice(), shelved_balance));
+        assert_ok!(EvmBalances::shelve(&ALICE, shelved_balance));
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - shelved_balance
         );
         assert_eq!(
@@ -567,7 +559,7 @@ fn shelve_works() {
             2 * INIT_BALANCE - shelved_balance
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Suspended {
-            who: alice(),
+            who: ALICE,
             amount: shelved_balance,
         }));
 
@@ -579,7 +571,7 @@ fn shelve_works() {
 fn shelve_works_exact_full_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         // Set block number to enable events.
@@ -588,18 +580,18 @@ fn shelve_works_exact_full_balance() {
         let shelved_balance = INIT_BALANCE;
 
         // Invoke the function under test.
-        assert_ok!(EvmBalances::shelve(&alice(), shelved_balance));
+        assert_ok!(EvmBalances::shelve(&ALICE, shelved_balance));
 
         // Assert state changes.
-        assert_eq!(EvmBalances::total_balance(&alice()), 0);
+        assert_eq!(EvmBalances::total_balance(&ALICE), 0);
         assert_eq!(EvmBalances::total_issuance(), INIT_BALANCE);
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Suspended {
-            who: alice(),
+            who: ALICE,
             amount: INIT_BALANCE,
         }));
-        assert!(!EvmSystem::account_exists(&alice()));
+        assert!(!EvmSystem::account_exists(&ALICE));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: alice() },
+            pallet_evm_system::Event::KilledAccount { account: ALICE },
         ));
 
         assert_total_issuance_invariant();
@@ -610,7 +602,7 @@ fn shelve_works_exact_full_balance() {
 fn shelve_fails_funds_unavailable() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         // Set block number to enable events.
@@ -620,7 +612,7 @@ fn shelve_fails_funds_unavailable() {
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::shelve(&alice(), shelved_balance),
+            EvmBalances::shelve(&ALICE, shelved_balance),
             TokenError::FundsUnavailable
         );
     });
@@ -630,7 +622,7 @@ fn shelve_fails_funds_unavailable() {
 fn restore_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         // Set block number to enable events.
@@ -639,11 +631,11 @@ fn restore_works() {
         let restored_balance = 10;
 
         // Invoke the function under test.
-        assert_ok!(EvmBalances::restore(&alice(), restored_balance));
+        assert_ok!(EvmBalances::restore(&ALICE, restored_balance));
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE + restored_balance
         );
         assert_eq!(
@@ -651,7 +643,7 @@ fn restore_works() {
             2 * INIT_BALANCE + restored_balance
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Restored {
-            who: alice(),
+            who: ALICE,
             amount: restored_balance,
         }));
 
@@ -663,13 +655,13 @@ fn restore_works() {
 fn restore_fails_overflow() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let restored_balance = u64::MAX;
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::restore(&alice(), restored_balance),
+            EvmBalances::restore(&ALICE, restored_balance),
             ArithmeticError::Overflow
         );
     });
@@ -679,7 +671,7 @@ fn restore_fails_overflow() {
 fn transfer_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let transferred_amount = 100;
 
@@ -688,24 +680,24 @@ fn transfer_works() {
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::transfer(
-            &alice(),
-            &bob(),
+            &ALICE,
+            &BOB,
             transferred_amount,
             Preservation::Preserve
         ));
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - transferred_amount
         );
         assert_eq!(
-            EvmBalances::total_balance(&bob()),
+            EvmBalances::total_balance(&BOB),
             INIT_BALANCE + transferred_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Transfer {
-            from: alice(),
-            to: bob(),
+            from: ALICE,
+            to: BOB,
             amount: transferred_amount,
         }));
 
@@ -717,7 +709,7 @@ fn transfer_works() {
 fn transfer_works_full_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let transferred_amount = INIT_BALANCE;
 
@@ -726,29 +718,29 @@ fn transfer_works_full_balance() {
 
         // Invoke the function under test.
         assert_ok!(EvmBalances::transfer(
-            &alice(),
-            &bob(),
+            &ALICE,
+            &BOB,
             transferred_amount,
             Preservation::Expendable
         ));
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - transferred_amount
         );
         assert_eq!(
-            EvmBalances::total_balance(&bob()),
+            EvmBalances::total_balance(&BOB),
             INIT_BALANCE + transferred_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Transfer {
-            from: alice(),
-            to: bob(),
+            from: ALICE,
+            to: BOB,
             amount: transferred_amount,
         }));
-        assert!(!EvmSystem::account_exists(&alice()));
+        assert!(!EvmSystem::account_exists(&ALICE));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: alice() },
+            pallet_evm_system::Event::KilledAccount { account: ALICE },
         ));
 
         assert_total_issuance_invariant();
@@ -759,7 +751,7 @@ fn transfer_works_full_balance() {
 fn transfer_fails_funds_unavailable() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let transferred_amount = INIT_BALANCE + 1;
 
@@ -768,7 +760,7 @@ fn transfer_fails_funds_unavailable() {
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::transfer(&alice(), &bob(), transferred_amount, Preservation::Preserve),
+            EvmBalances::transfer(&ALICE, &BOB, transferred_amount, Preservation::Preserve),
             TokenError::FundsUnavailable
         );
     });
@@ -778,7 +770,7 @@ fn transfer_fails_funds_unavailable() {
 fn transfer_fails_not_expendable() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let transferred_amount = INIT_BALANCE;
 
@@ -787,7 +779,7 @@ fn transfer_fails_not_expendable() {
 
         // Invoke the function under test.
         assert_noop!(
-            EvmBalances::transfer(&alice(), &bob(), transferred_amount, Preservation::Preserve),
+            EvmBalances::transfer(&ALICE, &BOB, transferred_amount, Preservation::Preserve),
             TokenError::NotExpendable
         );
     });
@@ -873,7 +865,7 @@ fn issue_works() {
 fn deposit_flow_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let deposited_amount = 10;
 
@@ -881,20 +873,20 @@ fn deposit_flow_works() {
         System::set_block_number(1);
 
         // Invoke the function under test.
-        let debt = EvmBalances::deposit(&alice(), deposited_amount, Precision::Exact).unwrap();
+        let debt = EvmBalances::deposit(&ALICE, deposited_amount, Precision::Exact).unwrap();
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE + deposited_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Deposit {
-            who: alice(),
+            who: ALICE,
             amount: deposited_amount,
         }));
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
-        let _ = EvmBalances::settle(&bob(), debt, Preservation::Expendable);
+        let _ = EvmBalances::settle(&BOB, debt, Preservation::Expendable);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         assert_total_issuance_invariant();
@@ -924,7 +916,7 @@ fn deposit_works_new_account() {
             amount: deposited_amount,
         }));
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
-        let _ = EvmBalances::settle(&bob(), debt, Preservation::Expendable);
+        let _ = EvmBalances::settle(&BOB, debt, Preservation::Expendable);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
         assert!(EvmSystem::account_exists(&charlie));
         System::assert_has_event(RuntimeEvent::EvmSystem(
@@ -939,7 +931,7 @@ fn deposit_works_new_account() {
 fn withdraw_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let withdrawed_amount = 1000;
 
@@ -948,7 +940,7 @@ fn withdraw_works() {
 
         // Invoke the function under test.
         let credit = EvmBalances::withdraw(
-            &alice(),
+            &ALICE,
             withdrawed_amount,
             Precision::Exact,
             Preservation::Preserve,
@@ -958,15 +950,15 @@ fn withdraw_works() {
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - withdrawed_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(Event::Withdraw {
-            who: alice(),
+            who: ALICE,
             amount: withdrawed_amount,
         }));
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
-        let _ = EvmBalances::resolve(&bob(), credit);
+        let _ = EvmBalances::resolve(&BOB, credit);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         assert_total_issuance_invariant();
@@ -977,7 +969,7 @@ fn withdraw_works() {
 fn withdraw_works_full_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Check test preconditions.
-        assert_eq!(EvmBalances::total_balance(&alice()), INIT_BALANCE);
+        assert_eq!(EvmBalances::total_balance(&ALICE), INIT_BALANCE);
 
         let withdrawed_amount = INIT_BALANCE;
 
@@ -986,7 +978,7 @@ fn withdraw_works_full_balance() {
 
         // Invoke the function under test.
         let credit = EvmBalances::withdraw(
-            &alice(),
+            &ALICE,
             withdrawed_amount,
             Precision::Exact,
             Preservation::Expendable,
@@ -996,19 +988,19 @@ fn withdraw_works_full_balance() {
 
         // Assert state changes.
         assert_eq!(
-            EvmBalances::total_balance(&alice()),
+            EvmBalances::total_balance(&ALICE),
             INIT_BALANCE - withdrawed_amount
         );
         System::assert_has_event(RuntimeEvent::EvmBalances(crate::Event::Withdraw {
-            who: alice(),
+            who: ALICE,
             amount: withdrawed_amount,
         }));
-        assert!(!EvmSystem::account_exists(&alice()));
+        assert!(!EvmSystem::account_exists(&ALICE));
         System::assert_has_event(RuntimeEvent::EvmSystem(
-            pallet_evm_system::Event::KilledAccount { account: alice() },
+            pallet_evm_system::Event::KilledAccount { account: ALICE },
         ));
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
-        let _ = EvmBalances::resolve(&bob(), credit);
+        let _ = EvmBalances::resolve(&BOB, credit);
         assert_eq!(EvmBalances::total_issuance(), 2 * INIT_BALANCE);
 
         assert_total_issuance_invariant();

--- a/crates/pallet-evm-balances/src/tests/fungible_conformance_tests.rs
+++ b/crates/pallet-evm-balances/src/tests/fungible_conformance_tests.rs
@@ -1,0 +1,66 @@
+use frame_support::traits::fungible::{conformance_tests, Inspect, Mutate};
+use paste::paste;
+
+use crate::{mock::*, *};
+
+macro_rules! run_tests {
+    ($path:path, $($name:ident),*) => {
+		$(
+			paste! {
+				#[test]
+				fn [< $name _dust_trap_on >]() {
+					let trap_account = <Test as Config>::AccountId::from(65174286u64);
+					new_test_ext().execute_with_ext(|_| {
+						EvmBalances::set_balance(&trap_account, EvmBalances::minimum_balance());
+						$path::$name::<
+							EvmBalances,
+							<Test as Config>::AccountId,
+						>(Some(trap_account));
+					});
+				}
+
+				#[test]
+				fn [< $name _dust_trap_off >]() {
+					new_test_ext().execute_with_ext(|_| {
+						$path::$name::<
+							EvmBalances,
+							<Test as Config>::AccountId,
+						>(None);
+					});
+				}
+			}
+		)*
+	};
+	($path:path) => {
+		run_tests!(
+			$path,
+			mint_into_success,
+			mint_into_overflow,
+			mint_into_below_minimum,
+			burn_from_exact_success,
+			burn_from_best_effort_success,
+			burn_from_exact_insufficient_funds,
+			restore_success,
+			restore_overflow,
+			restore_below_minimum,
+			shelve_success,
+			shelve_insufficient_funds,
+			transfer_success,
+			transfer_expendable_all,
+			transfer_expendable_dust,
+			transfer_protect_preserve,
+			set_balance_mint_success,
+			set_balance_burn_success,
+			can_deposit_success,
+			can_deposit_below_minimum,
+			can_deposit_overflow,
+			can_withdraw_success,
+			can_withdraw_reduced_to_zero,
+			can_withdraw_balance_low,
+			reducible_balance_expendable,
+			reducible_balance_protect_preserve
+		);
+	};
+}
+
+run_tests!(conformance_tests::inspect_mutate);

--- a/crates/pallet-evm-balances/src/tests/mod.rs
+++ b/crates/pallet-evm-balances/src/tests/mod.rs
@@ -10,6 +10,7 @@ use crate::{mock::*, *};
 
 mod currency;
 mod fungible;
+mod fungible_conformance_tests;
 
 fn assert_total_issuance_invariant() {
     let iterated_total_issuance: u64 = <pallet_evm_system::Account<Test>>::iter_values()

--- a/crates/pallet-evm-balances/src/tests/mod.rs
+++ b/crates/pallet-evm-balances/src/tests/mod.rs
@@ -4,7 +4,6 @@ use frame_support::{assert_ok, traits::Currency, weights::Weight};
 use pallet_evm::{FeeCalculator, FixedGasWeightMapping, GasWeightMapping, Runner};
 use sp_core::{H160, U256};
 use sp_runtime::traits::UniqueSaturatedInto;
-use sp_std::str::FromStr;
 
 use crate::{mock::*, *};
 
@@ -43,8 +42,9 @@ fn basic_setup_works() {
 fn evm_system_removing_account_non_zero_balance() {
     new_test_ext().execute_with_ext(|_| {
         // Prepare test preconditions.
-        let contract = H160::from_str("1000000000000000000000000000000000000003").unwrap();
-        EVM::create_account(contract, vec![1, 2, 3]);
+        let contract = 3;
+        let contract_h160 = H160::from_low_u64_be(contract);
+        EVM::create_account(contract_h160, vec![1, 2, 3]);
 
         // Transfer some balance to contract address.
         assert_ok!(EvmBalances::transfer(
@@ -57,7 +57,7 @@ fn evm_system_removing_account_non_zero_balance() {
         assert_eq!(EvmBalances::free_balance(contract), 1000);
 
         // Invoke the function under test.
-        EVM::remove_account(&contract);
+        EVM::remove_account(&contract_h160);
 
         // Assert state changes.
         assert_eq!(EvmBalances::free_balance(contract), 1000);
@@ -70,7 +70,8 @@ fn evm_system_removing_account_non_zero_balance() {
 #[test]
 fn evm_fee_deduction() {
     new_test_ext().execute_with_ext(|_| {
-		let charlie = H160::from_str("1000000000000000000000000000000000000003").unwrap();
+		let charlie = 3;
+        let charlie_h160 = H160::from_low_u64_be(charlie);
 
 		// Seed account
 		let _ = <Test as pallet_evm::Config>::Currency::deposit_creating(&charlie, 100);
@@ -79,14 +80,14 @@ fn evm_fee_deduction() {
 		// Deduct fees as 10 units
 		let imbalance =
 			<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::withdraw_fee(
-				&charlie,
+				&charlie_h160,
 				U256::from(10),
 			)
 			.unwrap();
 		assert_eq!(EvmBalances::free_balance(charlie), 90);
 
 		// Refund fees as 5 units
-		<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&charlie, U256::from(5), U256::from(5), imbalance);
+		<<Test as pallet_evm::Config>::OnChargeTransaction as pallet_evm::OnChargeEVMTransaction<Test>>::correct_and_deposit_fee(&charlie_h160, U256::from(5), U256::from(5), imbalance);
 		assert_eq!(EvmBalances::free_balance(charlie), 95);
 
 		assert_total_issuance_invariant();
@@ -102,8 +103,8 @@ fn evm_issuance_after_tip() {
         let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
         assert_ok!(<Test as pallet_evm::Config>::Runner::call(
-            alice(),
-            bob(),
+            alice_h160(),
+            bob_h160(),
             Vec::new(),
             U256::from(1),
             gas_limit,
@@ -134,7 +135,7 @@ fn evm_issuance_after_tip() {
 #[test]
 fn evm_refunds_should_work() {
     new_test_ext().execute_with_ext(|_| {
-        let before_call = EVM::account_basic(&alice()).0.balance;
+        let before_call = EVM::account_basic(&alice_h160()).0.balance;
         // Gas price is not part of the actual fee calculations anymore, only the base fee.
         //
         // Because we first deduct max_fee_per_gas * gas_limit (2_000_000_000 * 1000000) we need
@@ -144,8 +145,8 @@ fn evm_refunds_should_work() {
         let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
         let _ = <Test as pallet_evm::Config>::Runner::call(
-            alice(),
-            bob(),
+            alice_h160(),
+            bob_h160(),
             Vec::new(),
             U256::from(1),
             gas_limit,
@@ -162,7 +163,7 @@ fn evm_refunds_should_work() {
 
         let (base_fee, _) = <Test as pallet_evm::Config>::FeeCalculator::min_gas_price();
         let total_cost = (U256::from(21_000) * base_fee) + U256::from(1);
-        let after_call = EVM::account_basic(&alice()).0.balance;
+        let after_call = EVM::account_basic(&alice_h160()).0.balance;
         assert_eq!(after_call, before_call - total_cost);
 
         assert_total_issuance_invariant();
@@ -172,7 +173,7 @@ fn evm_refunds_should_work() {
 #[test]
 fn evm_refunds_and_priority_should_work() {
     new_test_ext().execute_with_ext(|_| {
-        let before_call = EVM::account_basic(&alice()).0.balance;
+        let before_call = EVM::account_basic(&alice_h160()).0.balance;
         // We deliberately set a base fee + max tip > max fee.
         // The effective priority tip will be 1GWEI instead 1.5GWEI:
         // 		(max_fee_per_gas - base_fee).min(max_priority_fee)
@@ -185,8 +186,8 @@ fn evm_refunds_and_priority_should_work() {
         let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
         let _ = <Test as pallet_evm::Config>::Runner::call(
-            alice(),
-            bob(),
+            alice_h160(),
+            bob_h160(),
             Vec::new(),
             U256::from(1),
             gas_limit,
@@ -204,7 +205,7 @@ fn evm_refunds_and_priority_should_work() {
         let (base_fee, _) = <Test as pallet_evm::Config>::FeeCalculator::min_gas_price();
         let actual_tip = (max_fee_per_gas - base_fee).min(tip) * used_gas;
         let total_cost = (used_gas * base_fee) + actual_tip + U256::from(1);
-        let after_call = EVM::account_basic(&alice()).0.balance;
+        let after_call = EVM::account_basic(&alice_h160()).0.balance;
         // The tip is deducted but never refunded to the caller.
         assert_eq!(after_call, before_call - total_cost);
 
@@ -222,8 +223,8 @@ fn evm_call_should_fail_with_priority_greater_than_max_fee() {
         let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
         let result = <Test as pallet_evm::Config>::Runner::call(
-            alice(),
-            bob(),
+            alice_h160(),
+            bob_h160(),
             Vec::new(),
             U256::from(1),
             gas_limit,
@@ -256,8 +257,8 @@ fn evm_call_should_succeed_with_priority_equal_to_max_fee() {
         // Mimics the input for pre-eip-1559 transaction types where `gas_price`
         // is used for both `max_fee_per_gas` and `max_priority_fee_per_gas`.
         let result = <Test as pallet_evm::Config>::Runner::call(
-            alice(),
-            bob(),
+            alice_h160(),
+            bob_h160(),
             Vec::new(),
             U256::from(1),
             gas_limit,

--- a/crates/pallet-evm-balances/src/tests/mod.rs
+++ b/crates/pallet-evm-balances/src/tests/mod.rs
@@ -26,11 +26,11 @@ fn basic_setup_works() {
     new_test_ext().execute_with_ext(|_| {
         // Check the accounts.
         assert_eq!(
-            <EvmBalances>::account(&alice()),
+            <EvmBalances>::account(&ALICE),
             account_data::AccountData { free: INIT_BALANCE }
         );
         assert_eq!(
-            <EvmBalances>::account(&bob()),
+            <EvmBalances>::account(&BOB),
             account_data::AccountData { free: INIT_BALANCE }
         );
 
@@ -48,7 +48,7 @@ fn evm_system_removing_account_non_zero_balance() {
 
         // Transfer some balance to contract address.
         assert_ok!(EvmBalances::transfer(
-            &alice(),
+            &ALICE,
             &contract,
             1000,
             ExistenceRequirement::KeepAlive
@@ -103,8 +103,8 @@ fn evm_issuance_after_tip() {
         let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
         assert_ok!(<Test as pallet_evm::Config>::Runner::call(
-            alice_h160(),
-            bob_h160(),
+            ALICE_H160,
+            BOB_H160,
             Vec::new(),
             U256::from(1),
             gas_limit,
@@ -135,7 +135,7 @@ fn evm_issuance_after_tip() {
 #[test]
 fn evm_refunds_should_work() {
     new_test_ext().execute_with_ext(|_| {
-        let before_call = EVM::account_basic(&alice_h160()).0.balance;
+        let before_call = EVM::account_basic(&ALICE_H160).0.balance;
         // Gas price is not part of the actual fee calculations anymore, only the base fee.
         //
         // Because we first deduct max_fee_per_gas * gas_limit (2_000_000_000 * 1000000) we need
@@ -145,8 +145,8 @@ fn evm_refunds_should_work() {
         let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
         let _ = <Test as pallet_evm::Config>::Runner::call(
-            alice_h160(),
-            bob_h160(),
+            ALICE_H160,
+            BOB_H160,
             Vec::new(),
             U256::from(1),
             gas_limit,
@@ -163,7 +163,7 @@ fn evm_refunds_should_work() {
 
         let (base_fee, _) = <Test as pallet_evm::Config>::FeeCalculator::min_gas_price();
         let total_cost = (U256::from(21_000) * base_fee) + U256::from(1);
-        let after_call = EVM::account_basic(&alice_h160()).0.balance;
+        let after_call = EVM::account_basic(&ALICE_H160).0.balance;
         assert_eq!(after_call, before_call - total_cost);
 
         assert_total_issuance_invariant();
@@ -173,7 +173,7 @@ fn evm_refunds_should_work() {
 #[test]
 fn evm_refunds_and_priority_should_work() {
     new_test_ext().execute_with_ext(|_| {
-        let before_call = EVM::account_basic(&alice_h160()).0.balance;
+        let before_call = EVM::account_basic(&ALICE_H160).0.balance;
         // We deliberately set a base fee + max tip > max fee.
         // The effective priority tip will be 1GWEI instead 1.5GWEI:
         // 		(max_fee_per_gas - base_fee).min(max_priority_fee)
@@ -186,8 +186,8 @@ fn evm_refunds_and_priority_should_work() {
         let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
         let _ = <Test as pallet_evm::Config>::Runner::call(
-            alice_h160(),
-            bob_h160(),
+            ALICE_H160,
+            BOB_H160,
             Vec::new(),
             U256::from(1),
             gas_limit,
@@ -205,7 +205,7 @@ fn evm_refunds_and_priority_should_work() {
         let (base_fee, _) = <Test as pallet_evm::Config>::FeeCalculator::min_gas_price();
         let actual_tip = (max_fee_per_gas - base_fee).min(tip) * used_gas;
         let total_cost = (used_gas * base_fee) + actual_tip + U256::from(1);
-        let after_call = EVM::account_basic(&alice_h160()).0.balance;
+        let after_call = EVM::account_basic(&ALICE_H160).0.balance;
         // The tip is deducted but never refunded to the caller.
         assert_eq!(after_call, before_call - total_cost);
 
@@ -223,8 +223,8 @@ fn evm_call_should_fail_with_priority_greater_than_max_fee() {
         let weight_limit = FixedGasWeightMapping::<Test>::gas_to_weight(gas_limit, true);
 
         let result = <Test as pallet_evm::Config>::Runner::call(
-            alice_h160(),
-            bob_h160(),
+            ALICE_H160,
+            BOB_H160,
             Vec::new(),
             U256::from(1),
             gas_limit,
@@ -257,8 +257,8 @@ fn evm_call_should_succeed_with_priority_equal_to_max_fee() {
         // Mimics the input for pre-eip-1559 transaction types where `gas_price`
         // is used for both `max_fee_per_gas` and `max_priority_fee_per_gas`.
         let result = <Test as pallet_evm::Config>::Runner::call(
-            alice_h160(),
-            bob_h160(),
+            ALICE_H160,
+            BOB_H160,
             Vec::new(),
             U256::from(1),
             gas_limit,


### PR DESCRIPTION
Closes #1438 

- [x] add the corresponding macro that runs https://github.com/humanode-network/substrate/tree/h-polkadot-v0.9.43/frame/support/src/traits/tokens/fungible/conformance_tests
- [x] adapt mock env to satisfy `AccountId: AtLeast8BitUnsigned`