### PR TITLE
Temporarily ignore `RUSTSEC-2023-0091` and `RUSTSEC-2024-0438` as a part of internal substrate deps

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -30,6 +30,10 @@ ignore = [
   "RUSTSEC-2024-0421",
   # TODO(#1478): update the ring internal dependency to 0.17.12+
   "RUSTSEC-2025-0009",
+  # TODO(#1541): update the wasmtime internal dependency to 24.0.2+
+  "RUSTSEC-2023-0091",
+  # TODO(#1542): update the wasmtime internal dependency to 24.0.2+
+  "RUSTSEC-2024-0438",
 ]
 
 [licenses]


### PR DESCRIPTION
Currently `wasmtime` version is explicitly set to `8.0.1` at substrate fork used now `polkadot-v0.9.43` - https://github.com/humanode-network/substrate/blob/8afcafd721d31939e4dee7b779f152ab9eb1c8be/primitives/wasm-interface/Cargo.toml#L21

The issues don't look crucial. So, the PR suggests to temporarily ignore `RUSTSEC-2023-0091` and `RUSTSEC-2024-0438` at deny config to avoid having conflicts in substrate fork
- https://rustsec.org/advisories/RUSTSEC-2023-0091.html
- https://rustsec.org/advisories/RUSTSEC-2024-0438.html