### PR TITLE
[evm-tracing-0-1] add debug e2e tests logic implementation

### DIFF
--- a/utils/e2e-tests/ts/lib/abis/debugTrace/callee.ts
+++ b/utils/e2e-tests/ts/lib/abis/debugTrace/callee.ts
@@ -1,0 +1,50 @@
+// pragma solidity >=0.8.3;
+//
+// contract TraceCallee {
+//     uint256 public store;
+//
+//     function addtwo(uint256 value) external returns (uint256 result) {
+//         uint256 x = 7;
+//         store = value;
+//         return value + x;
+//     }
+// }
+
+export default {
+  abi: [
+    {
+      inputs: [
+        {
+          internalType: "uint256",
+          name: "value",
+          type: "uint256",
+        },
+      ],
+      name: "addtwo",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "result",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "store",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+  ],
+  bytecode:
+    "0x6080604052348015600e575f5ffd5b506101cb8061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610034575f3560e01c8063975057e714610038578063fd63983b14610056575b5f5ffd5b610040610086565b60405161004d91906100c3565b60405180910390f35b610070600480360381019061006b919061010a565b61008b565b60405161007d91906100c3565b60405180910390f35b5f5481565b5f5f60079050825f8190555080836100a39190610162565b915050919050565b5f819050919050565b6100bd816100ab565b82525050565b5f6020820190506100d65f8301846100b4565b92915050565b5f5ffd5b6100e9816100ab565b81146100f3575f5ffd5b50565b5f81359050610104816100e0565b92915050565b5f6020828403121561011f5761011e6100dc565b5b5f61012c848285016100f6565b91505092915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f61016c826100ab565b9150610177836100ab565b925082820190508082111561018f5761018e610135565b5b9291505056fea264697066735822122021bf5f7d11f3386a1ddb70401a730984be0c92eb7804616e5ef6fc9ef1d6d6e864736f6c634300081e0033",
+} as const;

--- a/utils/e2e-tests/ts/lib/abis/debugTrace/caller.ts
+++ b/utils/e2e-tests/ts/lib/abis/debugTrace/caller.ts
@@ -1,0 +1,49 @@
+// pragma solidity >=0.8.3;
+//
+// contract TraceCaller {
+//     TraceCallee internal callee;
+//     uint256 public store;
+//
+//     function someAction(address addr, uint256 number) public {
+//         callee = TraceCallee(addr);
+//         store = callee.addtwo(number);
+//     }
+// }
+
+export default {
+  abi: [
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "addr",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "number",
+          type: "uint256",
+        },
+      ],
+      name: "someAction",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [],
+      name: "store",
+      outputs: [
+        {
+          internalType: "uint256",
+          name: "",
+          type: "uint256",
+        },
+      ],
+      stateMutability: "view",
+      type: "function",
+    },
+  ],
+  bytecode:
+    "0x6080604052348015600e575f5ffd5b506102c68061001c5f395ff3fe608060405234801561000f575f5ffd5b5060043610610034575f3560e01c8063398f722314610038578063975057e714610054575b5f5ffd5b610052600480360381019061004d91906101eb565b610072565b005b61005c610154565b6040516100699190610238565b60405180910390f35b815f5f6101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055505f5f9054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1663fd63983b826040518263ffffffff1660e01b815260040161010a9190610238565b6020604051808303815f875af1158015610126573d5f5f3e3d5ffd5b505050506040513d601f19601f8201168201806040525081019061014a9190610265565b6001819055505050565b60015481565b5f5ffd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f6101878261015e565b9050919050565b6101978161017d565b81146101a1575f5ffd5b50565b5f813590506101b28161018e565b92915050565b5f819050919050565b6101ca816101b8565b81146101d4575f5ffd5b50565b5f813590506101e5816101c1565b92915050565b5f5f604083850312156102015761020061015a565b5b5f61020e858286016101a4565b925050602061021f858286016101d7565b9150509250929050565b610232816101b8565b82525050565b5f60208201905061024b5f830184610229565b92915050565b5f8151905061025f816101c1565b92915050565b5f6020828403121561027a5761027961015a565b5b5f61028784828501610251565b9150509291505056fea264697066735822122019f0f10cf26630f53914cf389a6d6eab4acc8bea5cd28adaa7572a62ba7030eb64736f6c634300081e0033",
+} as const;

--- a/utils/e2e-tests/ts/lib/rpcUtils.ts
+++ b/utils/e2e-tests/ts/lib/rpcUtils.ts
@@ -1,0 +1,36 @@
+//! Common RPC utils.
+
+interface JsonRpcResponse {
+  result?: any;
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+export async function customRpcRequest(
+  endpoint: string,
+  method: string,
+  params: any[] = [],
+): Promise<any> {
+  const data = {
+    jsonrpc: "2.0",
+    id: 1,
+    method,
+    params,
+  };
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    body: JSON.stringify(data),
+    headers: { "Content-Type": "application/json" },
+  });
+
+  const responseData = (await response.json()) as JsonRpcResponse;
+
+  if (responseData.error) {
+    throw new Error(responseData.error.message);
+  }
+
+  return responseData.result;
+}

--- a/utils/e2e-tests/ts/tests/evm-tracing/debugTrace.ts
+++ b/utils/e2e-tests/ts/tests/evm-tracing/debugTrace.ts
@@ -1,0 +1,169 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { RunNodeState, runNode } from "../../lib/node";
+import * as eth from "../../lib/ethViem";
+import { beforeEachWithCleanup } from "../../lib/lifecycle";
+import callee from "../../lib/abis/debugTrace/callee";
+import caller from "../../lib/abis/debugTrace/caller";
+import { encodeFunctionData } from "viem";
+import { customRpcRequest } from "../../lib/rpcUtils";
+
+describe("test debug trace logic", () => {
+  let node: RunNodeState;
+  let publicClient: eth.PublicClientWebSocket;
+  let devClients: eth.DevClientsWebSocket;
+  beforeEachWithCleanup(async (cleanup) => {
+    node = runNode(
+      {
+        args: ["--ethapi=debug", "--dev", "--tmp"],
+      },
+      cleanup.push,
+    );
+
+    await node.waitForBoot;
+
+    publicClient = eth.publicClientFromNodeWebSocket(node, cleanup.push);
+    devClients = eth.devClientsFromNodeWebSocket(node, cleanup.push);
+  }, 60 * 1000);
+
+  let calleeAddress: `0x${string}`;
+  let callerAddress: `0x${string}`;
+
+  beforeEach(async () => {
+    const [alice, _] = devClients;
+
+    const deployCalleeContractTxHash = await alice.deployContract({
+      abi: callee.abi,
+      bytecode: callee.bytecode,
+    });
+    const deployCalleeContractTxReceipt =
+      await publicClient.waitForTransactionReceipt({
+        hash: deployCalleeContractTxHash,
+        timeout: 18_000,
+      });
+    calleeAddress = deployCalleeContractTxReceipt.contractAddress!;
+
+    const deployCallerContractTxHash = await alice.deployContract({
+      abi: caller.abi,
+      bytecode: caller.bytecode,
+    });
+    const deployCallerContractTxReceipt =
+      await publicClient.waitForTransactionReceipt({
+        hash: deployCallerContractTxHash,
+        timeout: 18_000,
+      });
+    callerAddress = deployCallerContractTxReceipt.contractAddress!;
+  });
+
+  describe("debug_traceCall tests", () => {
+    it("should trace nested contract calls", async () => {
+      const [alice, bob] = devClients;
+
+      const dummyTx = await alice.sendTransaction({
+        to: bob.account.address,
+        value: 1000n,
+      });
+      await publicClient.waitForTransactionReceipt({ hash: dummyTx });
+
+      const callParams = {
+        to: callerAddress,
+        data: encodeFunctionData({
+          abi: caller.abi,
+          functionName: "someAction",
+          args: [calleeAddress, 7n],
+        }),
+      };
+
+      const response = await customRpcRequest(
+        node.meta.rpcUrlHttp,
+        "debug_traceCall",
+        [callParams, "latest"],
+      );
+
+      const logs: any[] = [];
+      for (const log of response.structLogs) {
+        if (logs.length === 1) {
+          logs.push(log);
+        }
+        if (log.op === "RETURN") {
+          logs.push(log);
+        }
+      }
+      expect(logs).to.be.lengthOf(2);
+      expect(logs[0].depth).to.be.equal(2);
+      expect(logs[1].depth).to.be.equal(1);
+    });
+  });
+
+  describe("debug_traceTransaction tests", () => {
+    it("should trace nested contract calls", async () => {
+      const [alice, _] = devClients;
+
+      const txHash = await alice.sendTransaction({
+        to: callerAddress,
+        data: encodeFunctionData({
+          abi: caller.abi,
+          functionName: "someAction",
+          args: [calleeAddress, 7n],
+        }),
+      });
+      await publicClient.waitForTransactionReceipt({ hash: txHash });
+
+      const response = await customRpcRequest(
+        node.meta.rpcUrlHttp,
+        "debug_traceTransaction",
+        [txHash],
+      );
+
+      const logs: any[] = [];
+      for (const log of response.structLogs) {
+        if (logs.length === 1) {
+          logs.push(log);
+        }
+        if (log.op === "RETURN") {
+          logs.push(log);
+        }
+      }
+      expect(logs).to.be.lengthOf(2);
+      expect(logs[0].depth).to.be.equal(2);
+      expect(logs[1].depth).to.be.equal(1);
+    });
+  });
+
+  describe("debug_traceBlockByNumber and debug_traceBlockByHash tests", () => {
+    it("should trace block by number and hash", async () => {
+      const [alice, _] = devClients;
+
+      const txHash = await alice.sendTransaction({
+        to: callerAddress,
+        data: encodeFunctionData({
+          abi: caller.abi,
+          functionName: "someAction",
+          args: [calleeAddress, 7n],
+        }),
+      });
+      const txReceipt = await publicClient.waitForTransactionReceipt({
+        hash: txHash,
+      });
+      const blockNumberHex = txReceipt.blockNumber.toString(16);
+      const blockHash = txReceipt.blockHash;
+
+      const responseByNumber = await customRpcRequest(
+        node.meta.rpcUrlHttp,
+        "debug_traceBlockByNumber",
+        [blockNumberHex, { tracer: "callTracer" }],
+      );
+
+      expect(responseByNumber.length).to.equal(1);
+      expect(txHash).to.equal(responseByNumber[0].txHash);
+
+      const responseByHash = await customRpcRequest(
+        node.meta.rpcUrlHttp,
+        "debug_traceBlockByHash",
+        [blockHash, { tracer: "callTracer" }],
+      );
+
+      expect(responseByHash.length).to.equal(1);
+      expect(txHash).to.equal(responseByHash[0].txHash);
+    });
+  });
+});

--- a/utils/e2e-tests/ts/tests/evm-tracing/debugTraceCall.ts
+++ b/utils/e2e-tests/ts/tests/evm-tracing/debugTraceCall.ts
@@ -1,3 +1,0 @@
-import { test } from "vitest";
-
-test("todo", () => {});

--- a/utils/e2e-tests/ts/tests/evm-tracing/traceFilter.ts
+++ b/utils/e2e-tests/ts/tests/evm-tracing/traceFilter.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import { RunNodeState, runNode } from "../../lib/node";
+import * as eth from "../../lib/ethViem";
+import { beforeEachWithCleanup } from "../../lib/lifecycle";
+import { customRpcRequest } from "../../lib/rpcUtils";
+
+describe("test trace filter logic", () => {
+  let node: RunNodeState;
+  let publicClient: eth.PublicClientWebSocket;
+  let devClients: eth.DevClientsWebSocket;
+  beforeEachWithCleanup(async (cleanup) => {
+    node = runNode(
+      {
+        args: ["--ethapi=trace", "--dev", "--tmp"],
+      },
+      cleanup.push,
+    );
+
+    await node.waitForBoot;
+
+    publicClient = eth.publicClientFromNodeWebSocket(node, cleanup.push);
+    devClients = eth.devClientsFromNodeWebSocket(node, cleanup.push);
+  }, 60 * 1000);
+
+  it("should support filtering trace per fromAddress", async () => {
+    const [alice, bob] = devClients;
+
+    const txHash = await alice.sendTransaction({
+      to: bob.account.address,
+      value: 1_000_000n,
+    });
+    const txReceipt = await publicClient.waitForTransactionReceipt({
+      hash: txHash,
+    });
+    const blockNumberHex = txReceipt.blockNumber.toString(16);
+
+    const response = await customRpcRequest(
+      node.meta.rpcUrlHttp,
+      "trace_filter",
+      [
+        {
+          fromBlock: blockNumberHex,
+          toBlock: blockNumberHex,
+          fromAddress: [alice.account.address],
+        },
+      ],
+    );
+
+    expect(response.length).to.equal(1);
+    expect(txHash).to.equal(response[0].transactionHash);
+  });
+});


### PR DESCRIPTION
~~The example list of different existing debug RPC methods for Ethereum:~~
~~- https://therpc.io/docs/ethereum/debug-methods/debug_traceCall~~
~~- https://www.chainnodes.org/docs/ethereum/debug_traceCall~~
~~- https://docs.chainstack.com/reference/ethereum-tracecall~~
~~- https://geth.ethereum.org/docs/interacting-with-geth/rpc/ns-debug#debugtracecall~~

The team has agreed on using moonbeam as a base code for implementing EVM tracing related tests.

The following basic tests have been implemented:
- [trace_filter](https://github.com/moonbeam-foundation/moonbeam/blob/6417d37b03a2950d16e3619b47358cb94994e2c8/test/suites/tracing-tests/test-trace-filter.ts#L194)
- [debug_traceCall](https://github.com/moonbeam-foundation/moonbeam/blob/6417d37b03a2950d16e3619b47358cb94994e2c8/test/suites/tracing-tests/test-trace-call.ts#L12)
- [debug_traceTransaction](https://github.com/moonbeam-foundation/moonbeam/blob/6417d37b03a2950d16e3619b47358cb94994e2c8/test/suites/tracing-tests/test-trace-1.ts#L110)
- [debug_traceBlockByNumber and debug_traceBlockByHash](https://github.com/moonbeam-foundation/moonbeam/blob/6417d37b03a2950d16e3619b47358cb94994e2c8/test/suites/tracing-tests/test-trace-5.ts#L83)

Tested over [moonbeam-peer](https://github.com/moonbeam-foundation/moonbeam/tree/runtime-3800) in dev mode with [moonbase-runtime-3800-substitute-tracing.wasm](https://github.com/moonbeam-foundation/moonbeam-runtime-overrides/blob/master/wasm/moonbase-runtime-3800-substitute-tracing.wasm)  overrides
<img width="790" height="125" alt="Screenshot from 2025-08-07 14-21-22" src="https://github.com/user-attachments/assets/8aaa9f5c-5314-4011-9673-61f82ae6c9ce" />

