### PR TITLE
Introduce `skip-bash-tests` and `skip-ts-tests` flags to control e2e-tests jobs execution at CI

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -79,6 +79,7 @@ jobs:
             build-args: ""
           - suite: "try-runtime"
             build-args: "--features try-runtime"
+            skip-ts-tests: true
       fail-fast: false
     name: End-to-end tests / ${{ matrix.test.suite }}
     runs-on: ubuntu-24.04
@@ -104,6 +105,7 @@ jobs:
           BUILD_ARGS: ${{ matrix.test.build-args }}
 
       - name: Run bash e2e tests
+        if: matrix.test.skip-bash-tests != true
         run: utils/e2e-tests/bash/run-tests "$TEST_SUITE"
         env:
           TEST_SUITE: ${{ matrix.test.suite }}
@@ -111,6 +113,7 @@ jobs:
           RUNTIME_WASM_PATH: "target/release/wbuild/humanode-runtime/humanode_runtime.wasm"
 
       - name: Run ts e2e tests
+        if: matrix.test.skip-ts-tests != true
         run: utils/e2e-tests/ts/run-tests "$TEST_SUITE"
         env:
           TEST_SUITE: ${{ matrix.test.suite }}

--- a/utils/e2e-tests/ts/run-tests
+++ b/utils/e2e-tests/ts/run-tests
@@ -10,4 +10,4 @@ shift
 HUMANODE_PEER_PATH="$(realpath -s "$HUMANODE_PEER_PATH")"
 export HUMANODE_PEER_PATH
 
-exec yarn utils/e2e-tests/ts test "./${TEST_SUITE}/"
+exec yarn utils/e2e-tests/ts test "./tests/${TEST_SUITE}/"

--- a/utils/e2e-tests/ts/run-tests
+++ b/utils/e2e-tests/ts/run-tests
@@ -10,4 +10,4 @@ shift
 HUMANODE_PEER_PATH="$(realpath -s "$HUMANODE_PEER_PATH")"
 export HUMANODE_PEER_PATH
 
-exec yarn utils/e2e-tests/ts test "$TEST_SUITE"
+exec yarn utils/e2e-tests/ts test /"$TEST_SUITE"/

--- a/utils/e2e-tests/ts/run-tests
+++ b/utils/e2e-tests/ts/run-tests
@@ -10,4 +10,4 @@ shift
 HUMANODE_PEER_PATH="$(realpath -s "$HUMANODE_PEER_PATH")"
 export HUMANODE_PEER_PATH
 
-exec yarn utils/e2e-tests/ts test /"$TEST_SUITE"/
+exec yarn utils/e2e-tests/ts test "./${TEST_SUITE}/"

--- a/utils/e2e-tests/ts/run-tests
+++ b/utils/e2e-tests/ts/run-tests
@@ -10,6 +10,4 @@ shift
 HUMANODE_PEER_PATH="$(realpath -s "$HUMANODE_PEER_PATH")"
 export HUMANODE_PEER_PATH
 
-if [[ "$TEST_SUITE" == "base" ]]; then
-  exec yarn utils/e2e-tests/ts test
-fi
+exec yarn utils/e2e-tests/ts test "$TEST_SUITE"

--- a/utils/e2e-tests/ts/tests/base/eth/WeHMND.ts
+++ b/utils/e2e-tests/ts/tests/base/eth/WeHMND.ts
@@ -1,10 +1,10 @@
 import { expect, describe, beforeEach, it } from "vitest";
-import { RunNodeState, runNode } from "../../lib/node";
-import * as eth from "../../lib/ethViem";
+import { RunNodeState, runNode } from "../../../lib/node";
+import * as eth from "../../../lib/ethViem";
 import { decodeEventLog, parseEther } from "viem";
-import erc20abi from "../../lib/abis/erc20";
-import "../../lib/expect";
-import { beforeEachWithCleanup } from "../../lib/lifecycle";
+import erc20abi from "../../../lib/abis/erc20";
+import "../../../lib/expect";
+import { beforeEachWithCleanup } from "../../../lib/lifecycle";
 
 describe("WeHMND", () => {
   let node: RunNodeState;

--- a/utils/e2e-tests/ts/tests/base/eth/preserveNonceOnZeroContractBalance.ts
+++ b/utils/e2e-tests/ts/tests/base/eth/preserveNonceOnZeroContractBalance.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, assert } from "vitest";
-import { RunNodeState, runNode } from "../../lib/node";
-import * as eth from "../../lib/ethViem";
-import deposit from "../../lib/abis/deposit";
-import "../../lib/expect";
-import { beforeEachWithCleanup } from "../../lib/lifecycle";
+import { RunNodeState, runNode } from "../../../lib/node";
+import * as eth from "../../../lib/ethViem";
+import deposit from "../../../lib/abis/deposit";
+import "../../../lib/expect";
+import { beforeEachWithCleanup } from "../../../lib/lifecycle";
 
 describe("contract account's nonce", () => {
   let node: RunNodeState;

--- a/utils/e2e-tests/ts/tests/base/eth/selfdestruct.ts
+++ b/utils/e2e-tests/ts/tests/base/eth/selfdestruct.ts
@@ -1,9 +1,9 @@
 import { expect, describe, it } from "vitest";
-import { RunNodeState, runNode } from "../../lib/node";
-import * as eth from "../../lib/ethViem";
-import selfdestruct from "../../lib/abis/selfdestruct";
-import "../../lib/expect";
-import { beforeEachWithCleanup } from "../../lib/lifecycle";
+import { RunNodeState, runNode } from "../../../lib/node";
+import * as eth from "../../../lib/ethViem";
+import selfdestruct from "../../../lib/abis/selfdestruct";
+import "../../../lib/expect";
+import { beforeEachWithCleanup } from "../../../lib/lifecycle";
 import * as ethers from "ethers";
 
 describe("selfdestruct", () => {

--- a/utils/e2e-tests/ts/tests/base/rpc/eth.ts
+++ b/utils/e2e-tests/ts/tests/base/rpc/eth.ts
@@ -1,9 +1,9 @@
 import { expect, describe, it } from "vitest";
-import { RunNodeState, runNode } from "../../lib/node";
-import * as eth from "../../lib/ethEthers";
+import { RunNodeState, runNode } from "../../../lib/node";
+import * as eth from "../../../lib/ethEthers";
 import * as ethers from "ethers";
-import "../../lib/expect";
-import { beforeEachWithCleanup } from "../../lib/lifecycle";
+import "../../../lib/expect";
+import { beforeEachWithCleanup } from "../../../lib/lifecycle";
 
 describe("eth rpc", () => {
   let node: RunNodeState;

--- a/utils/e2e-tests/ts/tests/base/rpc/substrate.ts
+++ b/utils/e2e-tests/ts/tests/base/rpc/substrate.ts
@@ -1,7 +1,7 @@
 import { expect, it, describe } from "vitest";
-import { RunNodeState, runNode } from "../../lib/node";
-import * as substrate from "../../lib/substrate";
-import { beforeEachWithCleanup } from "../../lib/lifecycle";
+import { RunNodeState, runNode } from "../../../lib/node";
+import * as substrate from "../../../lib/substrate";
+import { beforeEachWithCleanup } from "../../../lib/lifecycle";
 
 describe("substrate rpc", () => {
   let node: RunNodeState;

--- a/utils/e2e-tests/ts/tests/base/swap/evmToNative.ts
+++ b/utils/e2e-tests/ts/tests/base/swap/evmToNative.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { RunNodeState, runNode } from "../../lib/node";
-import * as eth from "../../lib/ethViem";
-import "../../lib/expect";
-import { beforeEachWithCleanup } from "../../lib/lifecycle";
-import evmSwap from "../../lib/abis/evmSwap";
+import { RunNodeState, runNode } from "../../../lib/node";
+import * as eth from "../../../lib/ethViem";
+import "../../../lib/expect";
+import { beforeEachWithCleanup } from "../../../lib/lifecycle";
+import evmSwap from "../../../lib/abis/evmSwap";
 import { decodeEventLog } from "viem";
-import * as substrate from "../../lib/substrate";
-import { getEvents, getNativeBalance } from "../../lib/substrateUtils";
+import * as substrate from "../../../lib/substrate";
+import { getEvents, getNativeBalance } from "../../../lib/substrateUtils";
 
 const evmToNativeSwapPrecompileAddress =
   "0x0000000000000000000000000000000000000900";

--- a/utils/e2e-tests/ts/tests/base/swap/nativeToEvm.ts
+++ b/utils/e2e-tests/ts/tests/base/swap/nativeToEvm.ts
@@ -1,12 +1,12 @@
 import { expect, it, describe, assert } from "vitest";
-import { RunNodeState, runNode } from "../../lib/node";
-import * as substrate from "../../lib/substrate";
-import { beforeEachWithCleanup } from "../../lib/lifecycle";
+import { RunNodeState, runNode } from "../../../lib/node";
+import * as substrate from "../../../lib/substrate";
+import { beforeEachWithCleanup } from "../../../lib/lifecycle";
 import { Keyring } from "@polkadot/api";
 import { Codec, IEvent } from "@polkadot/types/types";
-import sendAndWait from "../../lib/substrateSendAndAwait";
-import * as eth from "../../lib/ethViem";
-import { getNativeBalance } from "../../lib/substrateUtils";
+import sendAndWait from "../../../lib/substrateSendAndAwait";
+import * as eth from "../../../lib/ethViem";
+import { getNativeBalance } from "../../../lib/substrateUtils";
 
 type EvmSwapBalancesSwappedEvent = Record<
   "from" | "withdrawedAmount" | "to" | "depositedAmount" | "evmTransactionHash",


### PR DESCRIPTION
As a follow up of work on https://github.com/humanode-network/humanode/pull/1574