### PR TITLE
Temporarily ignore RUSTSEC-2025-0055

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5086,11 +5086,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata 0.4.5",
 ]
 
 [[package]]
@@ -5537,12 +5537,11 @@ checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5847,12 +5846,6 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallet-authorship"
@@ -11061,14 +11054,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.18"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
 dependencies = [
- "matchers 0.1.0",
+ "matchers 0.2.0",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata 0.4.5",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -11084,7 +11077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
 dependencies = [
  "tracing-core",
- "tracing-subscriber 0.3.18",
+ "tracing-subscriber 0.3.20",
  "tracing-test-macro",
 ]
 

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,8 @@ ignore = [
   "RUSTSEC-2023-0091",
   # TODO(#1542): update the wasmtime internal dependency to 24.0.2+
   "RUSTSEC-2024-0438",
+  # TODO(#1612): update the tracing-subscriber internal dependency to 0.3.20+
+  "RUSTSEC-2025-0055",
 ]
 
 [licenses]


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2025-0055

We have internal substrate fork dependencies that depend on vulnerable `tracing-subscriber` version.

Agreed to ignore it for now until we update substrate version.